### PR TITLE
[Feat/#14] 프로필 수정 기능을 추가한다

### DIFF
--- a/src/main/java/com/justsayit/infra/s3/UploadImageService.java
+++ b/src/main/java/com/justsayit/infra/s3/UploadImageService.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.justsayit.infra.s3.dto.ProfileImgInfo;
 import com.justsayit.infra.s3.exception.FileMaximumSizeException;
 import com.justsayit.infra.s3.usecase.UploadImageUseCase;
-import com.justsayit.infra.s3.util.BasicProfileImgGenerator;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -32,9 +31,6 @@ public class UploadImageService implements UploadImageUseCase {
 
     @Override
     public ProfileImgInfo uploadProfileImg(MultipartFile multipartFile) {
-        if (multipartFile.isEmpty()) {
-            return new ProfileImgInfo(BasicProfileImgGenerator.getRandom());
-        }
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentType(multipartFile.getContentType());
         objectMetadata.setContentLength(multipartFile.getSize());

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.justsayit.member.controller;
 
 import com.justsayit.core.template.BaseResponse;
+import com.justsayit.member.controller.request.ChangedProfileReq;
 import com.justsayit.member.controller.request.LoginReq;
 import com.justsayit.member.service.LoginFacade;
 import com.justsayit.member.service.auth.dto.LoginRes;
 import com.justsayit.member.service.auth.usecase.AuthUseCase;
+import com.justsayit.member.service.profile.usecase.ProfileUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +19,7 @@ public class MemberController {
 
     private final LoginFacade loginFacade;
     private final AuthUseCase authUseCase;
+    private final ProfileUseCase profileUseCase;
 
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<LoginRes>> login(@RequestPart(value = "loginInfo") LoginReq req, @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
@@ -25,8 +28,14 @@ public class MemberController {
     }
 
     @PostMapping("/quit/{member-id}")
-    public ResponseEntity<BaseResponse> quit(@PathVariable(name = "member-id") Long memberId) {
+    public ResponseEntity<BaseResponse<Object>> quit(@PathVariable(name = "member-id") Long memberId) {
         authUseCase.quit(memberId);
         return ResponseEntity.ok(BaseResponse.ofSuccess("AUTH-002", "회원탈퇴 성공"));
+    }
+
+    @PatchMapping("/profile/me/{member-id}")
+    public ResponseEntity<BaseResponse<Object>> changeMyProfile(@RequestPart(value = "changedProfile") ChangedProfileReq req,
+                                                                            @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
+        return null;
     }
 }

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -3,10 +3,10 @@ package com.justsayit.member.controller;
 import com.justsayit.core.template.BaseResponse;
 import com.justsayit.member.controller.request.LoginReq;
 import com.justsayit.member.controller.request.UpdateProfileReq;
-import com.justsayit.member.service.LoginFacade;
+import com.justsayit.member.service.auth.LoginFacade;
 import com.justsayit.member.service.auth.dto.LoginRes;
 import com.justsayit.member.service.auth.usecase.AuthUseCase;
-import com.justsayit.member.service.profile.usecase.ProfileUseCase;
+import com.justsayit.member.service.profile.UpdateProfileFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +18,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
     private final LoginFacade loginFacade;
+    private final UpdateProfileFacade updateProfileFacade;
     private final AuthUseCase authUseCase;
-    private final ProfileUseCase profileUseCase;
 
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<LoginRes>> login(@RequestPart(value = "loginInfo") LoginReq req, @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
@@ -34,9 +34,10 @@ public class MemberController {
     }
 
     @PatchMapping("/profile/me/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> updateMyProfile(@PathVariable(name = "member-id") Long memberId,
+    public ResponseEntity<BaseResponse<Object>> updateProfile(@PathVariable(name = "member-id") Long memberId,
                                                                 @RequestPart(value = "updateProfile") UpdateProfileReq req,
                                                                 @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
+        updateProfileFacade.updateProfile(memberId, req, multipartFile);
         return null;
     }
 }

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.justsayit.member.controller;
 
 import com.justsayit.core.template.BaseResponse;
-import com.justsayit.member.controller.request.ChangedProfileReq;
 import com.justsayit.member.controller.request.LoginReq;
+import com.justsayit.member.controller.request.UpdateProfileReq;
 import com.justsayit.member.service.LoginFacade;
 import com.justsayit.member.service.auth.dto.LoginRes;
 import com.justsayit.member.service.auth.usecase.AuthUseCase;
@@ -34,8 +34,9 @@ public class MemberController {
     }
 
     @PatchMapping("/profile/me/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> changeMyProfile(@RequestPart(value = "changedProfile") ChangedProfileReq req,
-                                                                            @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
+    public ResponseEntity<BaseResponse<Object>> updateMyProfile(@PathVariable(name = "member-id") Long memberId,
+                                                                @RequestPart(value = "updateProfile") UpdateProfileReq req,
+                                                                @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
         return null;
     }
 }

--- a/src/main/java/com/justsayit/member/controller/request/ChangedProfileReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/ChangedProfileReq.java
@@ -1,0 +1,13 @@
+package com.justsayit.member.controller.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChangedProfileReq {
+
+    private String nickname;
+    private String profileImg;
+}

--- a/src/main/java/com/justsayit/member/controller/request/UpdateProfileReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/UpdateProfileReq.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChangedProfileReq {
+public class UpdateProfileReq {
 
     private String nickname;
     private String profileImg;

--- a/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
+++ b/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
@@ -2,6 +2,7 @@ package com.justsayit.member.service.auth;
 
 import com.justsayit.infra.s3.dto.ProfileImgInfo;
 import com.justsayit.infra.s3.usecase.UploadImageUseCase;
+import com.justsayit.infra.s3.util.BasicProfileImgGenerator;
 import com.justsayit.member.controller.request.LoginReq;
 import com.justsayit.member.service.auth.command.LoginCommand;
 import com.justsayit.member.service.auth.dto.LoginRes;
@@ -20,7 +21,10 @@ public class LoginFacade {
     private final AuthUseCase authUseCase;
 
     public LoginRes login(LoginReq req, MultipartFile multipartFile) {
-        ProfileImgInfo profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
+        ProfileImgInfo profileImgInfo = new ProfileImgInfo(BasicProfileImgGenerator.getRandom());
+        if (multipartFile.isEmpty()) {
+            profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
+        }
         return authUseCase.login(LoginCommand.builder()
                 .token(req.getToken())
                 .nickname(req.getNickname())

--- a/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
+++ b/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
@@ -1,4 +1,4 @@
-package com.justsayit.member.service;
+package com.justsayit.member.service.auth;
 
 import com.justsayit.infra.s3.dto.ProfileImgInfo;
 import com.justsayit.infra.s3.usecase.UploadImageUseCase;

--- a/src/main/java/com/justsayit/member/service/profile/ProfileService.java
+++ b/src/main/java/com/justsayit/member/service/profile/ProfileService.java
@@ -1,0 +1,28 @@
+package com.justsayit.member.service.profile;
+
+import com.justsayit.member.domain.Member;
+import com.justsayit.member.domain.ProfileInfo;
+import com.justsayit.member.repository.MemberRepository;
+import com.justsayit.member.service.profile.command.UpdateProfileCmd;
+import com.justsayit.member.service.profile.usecase.ProfileUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProfileService implements ProfileUseCase {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void updateProfile(UpdateProfileCmd cmd) {
+        Member member = memberRepository.findById(cmd.getMemberId())
+                .orElseThrow();
+        member.updateProfile(ProfileInfo.builder()
+                .nickname(cmd.getNickname())
+                .profileImg(cmd.getProfileImg())
+                .build());
+    }
+}

--- a/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
+++ b/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
@@ -23,7 +23,6 @@ public class UpdateProfileFacade {
         if (!multipartFile.isEmpty()) {
             profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
         }
-        // 프로필 정보 수정
         profileUseCase.updateProfile(UpdateProfileCmd.builder()
                 .memberId(memberId)
                 .nickname(req.getNickname())

--- a/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
+++ b/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
@@ -1,0 +1,33 @@
+package com.justsayit.member.service.profile;
+
+import com.justsayit.infra.s3.dto.ProfileImgInfo;
+import com.justsayit.infra.s3.usecase.UploadImageUseCase;
+import com.justsayit.member.controller.request.UpdateProfileReq;
+import com.justsayit.member.service.profile.command.UpdateProfileCmd;
+import com.justsayit.member.service.profile.usecase.ProfileUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateProfileFacade {
+
+    private final UploadImageUseCase uploadImageUseCase;
+    private final ProfileUseCase profileUseCase;
+
+    public void updateProfile(Long memberId, UpdateProfileReq req, MultipartFile multipartFile) {
+        ProfileImgInfo profileImgInfo = new ProfileImgInfo(req.getProfileImg());
+        if (!multipartFile.isEmpty()) {
+            profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
+        }
+        // 프로필 정보 수정
+        profileUseCase.updateProfile(UpdateProfileCmd.builder()
+                .memberId(memberId)
+                .nickname(req.getNickname())
+                .profileImg(profileImgInfo.getUrl())
+                .build());
+    }
+}

--- a/src/main/java/com/justsayit/member/service/profile/command/UpdateProfileCmd.java
+++ b/src/main/java/com/justsayit/member/service/profile/command/UpdateProfileCmd.java
@@ -1,0 +1,19 @@
+package com.justsayit.member.service.profile.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UpdateProfileCmd {
+
+    private Long memberId;
+    private String nickname;
+    private String profileImg;
+
+    @Builder
+    public UpdateProfileCmd(Long memberId, String nickname, String profileImg) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+    }
+}

--- a/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
+++ b/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
@@ -1,0 +1,4 @@
+package com.justsayit.member.service.profile.usecase;
+
+public interface ProfileUseCase {
+}

--- a/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
+++ b/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
@@ -1,4 +1,8 @@
 package com.justsayit.member.service.profile.usecase;
 
+import com.justsayit.member.service.profile.command.UpdateProfileCmd;
+
 public interface ProfileUseCase {
+
+    void updateProfile(UpdateProfileCmd build);
 }

--- a/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
+++ b/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
@@ -4,5 +4,5 @@ import com.justsayit.member.service.profile.command.UpdateProfileCmd;
 
 public interface ProfileUseCase {
 
-    void updateProfile(UpdateProfileCmd build);
+    void updateProfile(UpdateProfileCmd cmd);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #14

### Key Point
- 사진을 수정한 경우 새로운 사진으로 변경, 그렇지 않은 경우 기존 이미지를 유지
- 사진 업로드, 프로필 정보 수정 로직에 퍼사드 패턴을 적용
  - 서비스간 느슨한 결합, 재사용성 향상 

### Other
- 기존에 사용하던 이미지를 S3 버킷에서 제거시킬 수 있는가 