### PR TITLE
[Fix/#27] 프로필 수정 기능에 시큐리티 적용 & 반환값을 추가한다

### DIFF
--- a/src/main/java/com/justsayit/core/security/config/SecurityConfig.java
+++ b/src/main/java/com/justsayit/core/security/config/SecurityConfig.java
@@ -51,8 +51,10 @@ public class SecurityConfig {
                     .antMatchers("/health/**")
                     .permitAll()
                     // MEMBER
+                    .antMatchers("/members/login")
+                    .permitAll()
                     .antMatchers("/members/**")
-                    .permitAll();
+                    .authenticated();
             return http.build();
         } catch (Exception e) {
             log.info("security config 에러 발생", e);

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -24,13 +24,13 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<LoginRes>> login(@RequestPart(value = "loginInfo") LoginReq req, @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
         LoginRes res = loginFacade.login(req, multipartFile);
-        return ResponseEntity.ok(BaseResponse.ofSuccess("AUTH-001", "로그인 성공", res));  // TODO 응답 메시지 전역변수 처리
+        return ResponseEntity.ok(BaseResponse.ofSuccess("1001", "로그인 성공", res));  // TODO 응답 메시지 전역변수 처리
     }
 
     @PostMapping("/quit/{member-id}")
     public ResponseEntity<BaseResponse<Object>> quit(@PathVariable(name = "member-id") Long memberId) {
         authUseCase.quit(memberId);
-        return ResponseEntity.ok(BaseResponse.ofSuccess("AUTH-002", "회원탈퇴 성공"));
+        return ResponseEntity.ok(BaseResponse.ofSuccess("1002", "회원탈퇴 성공"));
     }
 
     @PatchMapping("/profile/me/{member-id}")
@@ -38,6 +38,6 @@ public class MemberController {
                                                                 @RequestPart(value = "updateProfile") UpdateProfileReq req,
                                                                 @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
         updateProfileFacade.updateProfile(memberId, req, multipartFile);
-        return null;
+        return ResponseEntity.ok(BaseResponse.ofSuccess("1003", "프로필 수정 성공"));
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #27 

### Key Point
- 프로필 수정 요청 시 토큰 인증 필요
- 사진을 새롭게 추가하지 않은 경우 이전 프로필 사진을 유지, 반면 새롭게 이미지를 첨부한 경우 교체

### Other
- 없음