### PR TITLE
[Fix/#29] 회원 도메인에 성별, 생년월일 정보를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/member/controller/request/LoginReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/LoginReq.java
@@ -1,6 +1,7 @@
 package com.justsayit.member.controller.request;
 
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -12,6 +13,7 @@ public class LoginReq {
 
     private String nickname;
     private String gender;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birth;
     private String loginType;
     private String token;

--- a/src/main/java/com/justsayit/member/controller/request/LoginReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/LoginReq.java
@@ -2,6 +2,8 @@ package com.justsayit.member.controller.request;
 
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -9,6 +11,8 @@ import lombok.*;
 public class LoginReq {
 
     private String nickname;
+    private String gender;
+    private LocalDate birth;
     private String loginType;
     private String token;
 }

--- a/src/main/java/com/justsayit/member/domain/Gender.java
+++ b/src/main/java/com/justsayit/member/domain/Gender.java
@@ -1,0 +1,7 @@
+package com.justsayit.member.domain;
+
+public enum Gender {
+
+    MALE,
+    FEMALE,
+}

--- a/src/main/java/com/justsayit/member/domain/Member.java
+++ b/src/main/java/com/justsayit/member/domain/Member.java
@@ -33,6 +33,12 @@ public class Member extends BaseJpaEntity {
     @AttributeOverride(name = "profileImg", column = @Column(name = "profile_img", nullable = false))
     private ProfileInfo profileInfo;
 
+
+    @Embedded
+    @AttributeOverride(name = "gender", column = @Column(name = "gender", nullable = false))
+    @AttributeOverride(name = "birth", column = @Column(name = "birth", nullable = false))
+    private PersonalInfo personalInfo;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private MemberStatus status;
@@ -42,10 +48,11 @@ public class Member extends BaseJpaEntity {
     private List<String> authorities = new ArrayList<>();
 
     @Builder
-    public Member(String token, String loginType, ProfileInfo profileInfo) {
+    public Member(String token, String loginType, ProfileInfo profileInfo, PersonalInfo personalInfo) {
         this.token = token;
         this.loginType = LoginType.valueOf(loginType);
         this.profileInfo = profileInfo;
+        this.personalInfo = personalInfo;
         this.status = MemberStatus.ACTIVE;
         this.authorities = List.of("MEMBER");
     }

--- a/src/main/java/com/justsayit/member/domain/PersonalInfo.java
+++ b/src/main/java/com/justsayit/member/domain/PersonalInfo.java
@@ -1,0 +1,25 @@
+package com.justsayit.member.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.time.LocalDate;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalInfo {
+
+    private Gender gender;
+    private LocalDate birth;
+
+    @Builder
+    public PersonalInfo(Gender gender, LocalDate birth) {
+        this.gender = gender;
+        this.birth = birth;
+    }
+}

--- a/src/main/java/com/justsayit/member/domain/PersonalInfo.java
+++ b/src/main/java/com/justsayit/member/domain/PersonalInfo.java
@@ -18,8 +18,8 @@ public class PersonalInfo {
     private LocalDate birth;
 
     @Builder
-    public PersonalInfo(Gender gender, LocalDate birth) {
-        this.gender = gender;
+    public PersonalInfo(String gender, LocalDate birth) {
+        this.gender = Gender.valueOf(gender);
         this.birth = birth;
     }
 }

--- a/src/main/java/com/justsayit/member/domain/PersonalInfo.java
+++ b/src/main/java/com/justsayit/member/domain/PersonalInfo.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import java.time.LocalDate;
 
 @Getter
@@ -14,7 +16,9 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PersonalInfo {
 
+    @Enumerated(value = EnumType.STRING)
     private Gender gender;
+
     private LocalDate birth;
 
     @Builder

--- a/src/main/java/com/justsayit/member/domain/ProfileInfo.java
+++ b/src/main/java/com/justsayit/member/domain/ProfileInfo.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
-import java.time.LocalDate;
 
 @Getter
 @Embeddable
@@ -16,16 +15,12 @@ public class ProfileInfo {
 
     private String nickname;
     private String profileImg;
-    private Gender gender;
-    private LocalDate birth;
 
     @Builder
-    public ProfileInfo(String nickname, String profileImg, String gender, LocalDate birth) {
+    public ProfileInfo(String nickname, String profileImg) {
         validateLength(nickname);
         this.nickname = nickname;
         this.profileImg = profileImg;
-        this.gender = Gender.valueOf(gender);
-        this.birth = birth;
     }
 
     private void validateLength(String nickname) {

--- a/src/main/java/com/justsayit/member/domain/ProfileInfo.java
+++ b/src/main/java/com/justsayit/member/domain/ProfileInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
+import java.time.LocalDate;
 
 @Getter
 @Embeddable
@@ -15,12 +16,16 @@ public class ProfileInfo {
 
     private String nickname;
     private String profileImg;
+    private Gender gender;
+    private LocalDate birth;
 
     @Builder
-    public ProfileInfo(String nickname, String profileImg) {
+    public ProfileInfo(String nickname, String profileImg, String gender, LocalDate birth) {
         validateLength(nickname);
         this.nickname = nickname;
         this.profileImg = profileImg;
+        this.gender = Gender.valueOf(gender);
+        this.birth = birth;
     }
 
     private void validateLength(String nickname) {

--- a/src/main/java/com/justsayit/member/service/auth/AuthService.java
+++ b/src/main/java/com/justsayit/member/service/auth/AuthService.java
@@ -3,6 +3,7 @@ package com.justsayit.member.service.auth;
 import com.justsayit.core.jwt.JwtTokenProvider;
 import com.justsayit.core.jwt.dto.JwtToken;
 import com.justsayit.member.domain.Member;
+import com.justsayit.member.domain.PersonalInfo;
 import com.justsayit.member.domain.ProfileInfo;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.auth.command.LoginCommand;
@@ -39,6 +40,10 @@ public class AuthService implements AuthUseCase {
                 .profileInfo(ProfileInfo.builder()
                         .nickname(cmd.getNickname())
                         .profileImg(cmd.getProfileImg())
+                        .build())
+                .personalInfo(PersonalInfo.builder()
+                        .gender(cmd.getGender())
+                        .birth(cmd.getBirth())
                         .build())
                 .build();
     }

--- a/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
+++ b/src/main/java/com/justsayit/member/service/auth/LoginFacade.java
@@ -30,6 +30,8 @@ public class LoginFacade {
                 .nickname(req.getNickname())
                 .loginType(req.getLoginType())
                 .profileImg(profileImgInfo.getUrl())
+                .birth(req.getBirth())
+                .gender(req.getGender())
                 .build());
     }
 }

--- a/src/main/java/com/justsayit/member/service/auth/command/LoginCommand.java
+++ b/src/main/java/com/justsayit/member/service/auth/command/LoginCommand.java
@@ -3,6 +3,8 @@ package com.justsayit.member.service.auth.command;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 public class LoginCommand {
 
@@ -10,12 +12,16 @@ public class LoginCommand {
     private String loginType;
     private String nickname;
     private String profileImg;
+    private String gender;
+    private LocalDate birth;
 
     @Builder
-    public LoginCommand(String token, String loginType, String nickname, String profileImg) {
+    public LoginCommand(String token, String loginType, String nickname, String profileImg, String gender, LocalDate birth) {
         this.token = token;
         this.loginType = loginType;
         this.nickname = nickname;
         this.profileImg = profileImg;
+        this.gender = gender;
+        this.birth = birth;
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #29 

### Key Point
- req 클래스에 직렬화 옵션을 추가한다
- 성별, 생년월일은 이후 수정 불가능

### Other
- 없음