### PR TITLE
[Fix/#55] 스토리 사진 업로드시 NPE가 발생하는 에러를 수정한다

### DIFF
--- a/src/main/java/com/justsayit/story/service/write/AddStoryFacade.java
+++ b/src/main/java/com/justsayit/story/service/write/AddStoryFacade.java
@@ -9,6 +9,7 @@ import com.justsayit.story.service.write.usecase.AddStoryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
@@ -25,10 +26,10 @@ public class AddStoryFacade {
 
     public void addStory(Long memberId, AddStoryReq req, List<MultipartFile> multipartFileList) {
         List<StoryPhoto> imgInfoList = new ArrayList<>();
-        if (multipartFileList.size() > MAX_IMG_SIZE) {
-            throw new InvalidNumberOfImgException();
-        }
-        if (multipartFileList != null) {
+        if (!CollectionUtils.isEmpty(multipartFileList)) {
+            if (multipartFileList.size() > MAX_IMG_SIZE) {
+                throw new InvalidNumberOfImgException();
+            }
             imgInfoList = uploadImageUseCase.uploadStoryImg(multipartFileList);
         }
         addStoryUseCase.addStory(AddStoryCommand.builder()


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #55 

### Key Point
- null 체크 후 최대 사진 개수 확인하도록 로직 변경

### Other
- 없음