### PR TITLE
[Feat/#71] 스토리 삭제 API를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/core/exception/advice/StoryExceptionHandler.java
+++ b/src/main/java/com/justsayit/core/exception/advice/StoryExceptionHandler.java
@@ -2,9 +2,7 @@ package com.justsayit.core.exception.advice;
 
 import com.justsayit.core.template.response.BaseResponse;
 import com.justsayit.core.template.response.ResponseCode;
-import com.justsayit.story.exception.InvalidBodyTextException;
-import com.justsayit.story.exception.InvalidEmotionCodeException;
-import com.justsayit.story.exception.InvalidNumberOfImgException;
+import com.justsayit.story.exception.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,5 +26,23 @@ public class StoryExceptionHandler {
     public ResponseEntity<BaseResponse<Object>> invalidBodyTextLengthException(InvalidBodyTextException e) {
         return ResponseEntity.badRequest()
                 .body(BaseResponse.ofFail(ResponseCode.INVALID_BODY_TEXT));
+    }
+
+    @ExceptionHandler(AlreadyDeletedStoryException.class)
+    public ResponseEntity<BaseResponse<Object>> alreadyDeletedStoryException(AlreadyDeletedStoryException e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.ALREADY_DELETED_STORY));
+    }
+
+    @ExceptionHandler(NoStoryException.class)
+    public ResponseEntity<BaseResponse<Object>> noStoryException(NoStoryException e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.NO_STORY));
+    }
+
+    @ExceptionHandler(NotMyStoryException.class)
+    public ResponseEntity<BaseResponse<Object>> notMyStoryException(NotMyStoryException e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.NOT_MY_STORY));
     }
 }

--- a/src/main/java/com/justsayit/core/template/response/ResponseCode.java
+++ b/src/main/java/com/justsayit/core/template/response/ResponseCode.java
@@ -26,6 +26,9 @@ public enum ResponseCode {
     INVALID_BODY_TEXT("5000", "본문 내용은 0자 이상 300자 이하까지 작성 가능하며 공백으로만 작성할 수 없습니다."),
     INVALID_EMOTION_CODE("5001", "잘못된 감정코드입니다."),
     INVALID_NUMBER_OF_IMG("5002", "스토리에 업로드 가능한 사진은 최대 4장입니다."),
+    ALREADY_DELETED_STORY("5003", "이미 삭제된 스토리입니다."),
+    NO_STORY("5004", "스토리가 존재하지 않습니다."),
+    NOT_MY_STORY("5005", "다른 회원이 작성한 스토리입니다."),
     ;
     private String code;
     private String message;

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -2,6 +2,8 @@ package com.justsayit.story.controller;
 
 import com.justsayit.core.template.response.BaseResponse;
 import com.justsayit.story.controller.request.AddStoryReq;
+import com.justsayit.story.service.edit.command.RemoveStoryCommand;
+import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
 import com.justsayit.story.service.read.command.StorySearchCondition;
 import com.justsayit.story.service.read.dto.GetStoryRes;
 import com.justsayit.story.service.read.usecase.GetStoryUseCase;
@@ -20,6 +22,7 @@ public class StoryController {
 
     private final AddStoryFacade addStoryFacade;
     private final GetStoryUseCase getStoryUseCase;
+    private final EditStoryUseCase editStoryUseCase;
 
     @PostMapping("/new/{member-id}")
     public ResponseEntity<BaseResponse<Object>> addStory(
@@ -72,5 +75,12 @@ public class StoryController {
                         .size(size)
                         .build());
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
+    }
+
+    @PatchMapping("/remove/{member-id}")
+    public ResponseEntity<BaseResponse<Object>> removeMyStory(@PathVariable(name = "member-id") Long memberId,
+                                                              @RequestParam(name = "story-id") Long storyId) {
+        editStoryUseCase.remove(new RemoveStoryCommand(memberId, storyId));
+        return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 }

--- a/src/main/java/com/justsayit/story/domain/Story.java
+++ b/src/main/java/com/justsayit/story/domain/Story.java
@@ -1,6 +1,7 @@
 package com.justsayit.story.domain;
 
 import com.justsayit.core.entity.BaseJpaEntity;
+import com.justsayit.story.exception.AlreadyDeletedStoryException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -80,5 +81,12 @@ public class Story extends BaseJpaEntity {
 
     public void changeMetaInfo(MetaInfo metaInfo) {
         this.metaInfo = metaInfo;
+    }
+
+    public void remove() {
+        if (this.status.equals(StoryStatus.DELETED)) {
+            throw new AlreadyDeletedStoryException();
+        }
+        this.status = StoryStatus.DELETED;
     }
 }

--- a/src/main/java/com/justsayit/story/exception/AlreadyDeletedStoryException.java
+++ b/src/main/java/com/justsayit/story/exception/AlreadyDeletedStoryException.java
@@ -1,0 +1,19 @@
+package com.justsayit.story.exception;
+
+public class AlreadyDeletedStoryException extends RuntimeException {
+
+    public AlreadyDeletedStoryException() {
+    }
+
+    public AlreadyDeletedStoryException(String message) {
+        super(message);
+    }
+
+    public AlreadyDeletedStoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AlreadyDeletedStoryException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/story/exception/NoStoryException.java
+++ b/src/main/java/com/justsayit/story/exception/NoStoryException.java
@@ -1,0 +1,19 @@
+package com.justsayit.story.exception;
+
+public class NoStoryException extends RuntimeException {
+
+    public NoStoryException() {
+    }
+
+    public NoStoryException(String message) {
+        super(message);
+    }
+
+    public NoStoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoStoryException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/story/exception/NotMyStoryException.java
+++ b/src/main/java/com/justsayit/story/exception/NotMyStoryException.java
@@ -1,0 +1,19 @@
+package com.justsayit.story.exception;
+
+public class NotMyStoryException extends RuntimeException {
+
+    public NotMyStoryException() {
+    }
+
+    public NotMyStoryException(String message) {
+        super(message);
+    }
+
+    public NotMyStoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotMyStoryException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
@@ -5,6 +5,7 @@ import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
 import com.justsayit.story.domain.Story;
 import com.justsayit.story.exception.NoStoryException;
+import com.justsayit.story.exception.NotMyStoryException;
 import com.justsayit.story.repository.StoryRepository;
 import com.justsayit.story.service.edit.command.RemoveStoryCommand;
 import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
@@ -26,6 +27,9 @@ public class EditStoryService implements EditStoryUseCase {
         Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
         Story story = storyRepository.findById(cmd.getStoryId())
                 .orElseThrow(NoStoryException::new);
+        if (!story.getMemberId().equals(member.getId())) {
+            throw new NotMyStoryException();
+        }
         story.remove();
     }
 }

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
@@ -1,0 +1,31 @@
+package com.justsayit.story.service.edit;
+
+import com.justsayit.member.domain.Member;
+import com.justsayit.member.repository.MemberRepository;
+import com.justsayit.member.service.MemberServiceHelper;
+import com.justsayit.story.domain.Story;
+import com.justsayit.story.exception.NoStoryException;
+import com.justsayit.story.repository.StoryRepository;
+import com.justsayit.story.service.edit.command.RemoveStoryCommand;
+import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EditStoryService implements EditStoryUseCase {
+
+    private final MemberRepository memberRepository;
+    private final StoryRepository storyRepository;
+
+    @Override
+    public void remove(RemoveStoryCommand cmd) {
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Story story = storyRepository.findById(cmd.getStoryId())
+                .orElseThrow(NoStoryException::new);
+        story.remove();
+    }
+}

--- a/src/main/java/com/justsayit/story/service/edit/command/RemoveStoryCommand.java
+++ b/src/main/java/com/justsayit/story/service/edit/command/RemoveStoryCommand.java
@@ -1,0 +1,15 @@
+package com.justsayit.story.service.edit.command;
+
+import lombok.Getter;
+
+@Getter
+public class RemoveStoryCommand {
+
+    private Long memberId;
+    private Long storyId;
+
+    public RemoveStoryCommand(Long memberId, Long storyId) {
+        this.memberId = memberId;
+        this.storyId = storyId;
+    }
+}

--- a/src/main/java/com/justsayit/story/service/edit/usecase/EditStoryUseCase.java
+++ b/src/main/java/com/justsayit/story/service/edit/usecase/EditStoryUseCase.java
@@ -1,0 +1,8 @@
+package com.justsayit.story.service.edit.usecase;
+
+import com.justsayit.story.service.edit.command.RemoveStoryCommand;
+
+public interface EditStoryUseCase {
+
+    void remove(RemoveStoryCommand cmd);
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #71 

### Key Point
- 나의 스토리만 삭제 가능
- 나의 스토리가 아니라면 예외 던짐
- 이미 삭제되었다면 예외 던짐

### Other
- 없음