### PR TITLE
[Fix/#81] 프로필 수정 시 기본 이미지로 변경하는 기능을 추가한다

### DIFF
--- a/src/main/java/com/justsayit/member/controller/request/UpdateProfileReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/UpdateProfileReq.java
@@ -10,4 +10,5 @@ public class UpdateProfileReq {
 
     private String nickname;
     private String profileImg;
+    private boolean defaultProfileImg;
 }

--- a/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
+++ b/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
@@ -21,7 +21,7 @@ public class UpdateProfileFacade {
     private final ProfileUseCase profileUseCase;
 
     public void updateProfile(Long memberId, UpdateProfileReq req, MultipartFile multipartFile) {
-        ProfileImgInfo profileImgInfo = ProfileImgInfo.of(req.getProfileImg());
+        ProfileImgInfo profileImgInfo = createProfileImgInfo(req);
         if (Objects.nonNull(multipartFile)) {
             profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
         }
@@ -30,5 +30,9 @@ public class UpdateProfileFacade {
                 .nickname(req.getNickname())
                 .profileImg(profileImgInfo.getUrl())
                 .build());
+    }
+
+    private ProfileImgInfo createProfileImgInfo(UpdateProfileReq req) {
+        return req.isDefaultProfileImg() ? ProfileImgInfo.ofDefault() : ProfileImgInfo.of(req.getProfileImg());
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #81 

### Key Point
- req 객체에 기본 이미지로 변경 여부를 저장하는 칼럼을 추가

### Other
- 없음