### PR TITLE
[Fix/#80] 시큐리티 컨텍스트로부터 사용자 정보를 조회하도록 service로직을 변경한다

### DIFF
--- a/src/main/java/com/justsayit/core/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/justsayit/core/jwt/JwtTokenProvider.java
@@ -28,6 +28,7 @@ public class JwtTokenProvider {
 
     @Value("${jwt.secret.expiration-time}")
     private int ACCESS_TOKEN_EXPRIATION_TIME;
+    private final String ROLE_MEMBER = "MEMBER";
 
     public JwtToken createToken(Long memberId) {
         String accessToken = createAccessToken(memberId);
@@ -37,15 +38,15 @@ public class JwtTokenProvider {
     public String createAccessToken(Long memberId) {
         log.info("secret key: {}", SECRET_KEY);
         StringBuilder sb = new StringBuilder();
-        sb.append("Bearer ");
-        sb.append(
-                Jwts.builder()
-                        .setSubject(memberId.toString())
-                        .claim("memberId", memberId)
-                        .claim("authorities", "MEMBER")
-                        .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPRIATION_TIME))
-                        .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
-                        .compact());
+        sb.append("Bearer ")
+                .append(
+                        Jwts.builder()
+                                .setSubject(memberId.toString())
+                                .claim("memberId", memberId)
+                                .claim("authorities", ROLE_MEMBER)
+                                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPRIATION_TIME))
+                                .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
+                                .compact());
         return sb.toString();
     }
 

--- a/src/main/java/com/justsayit/core/security/auth/AuthServiceHelper.java
+++ b/src/main/java/com/justsayit/core/security/auth/AuthServiceHelper.java
@@ -1,0 +1,16 @@
+package com.justsayit.core.security.auth;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+public final class AuthServiceHelper {
+
+    public static Long getMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        return Long.parseLong(userDetails.getUsername());
+    }
+}

--- a/src/main/java/com/justsayit/core/security/auth/PrincipalDetailService.java
+++ b/src/main/java/com/justsayit/core/security/auth/PrincipalDetailService.java
@@ -22,7 +22,7 @@ public class PrincipalDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String token) throws UsernameNotFoundException {
         Member member = memberRepository.findByToken(token).orElseThrow();
-        return new User(member.getToken(), null, mapToSimpleGrandAuthority(member));
+        return new User(String.valueOf(member.getId()), null, mapToSimpleGrandAuthority(member));
     }
 
     private List<SimpleGrantedAuthority> mapToSimpleGrandAuthority(Member member) {

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -60,10 +60,9 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.ofSuccess(getProfileRes));
     }
 
-    @PostMapping("/block/{blocker-id}")
-    public ResponseEntity<BaseResponse<Object>> blockMember(@PathVariable(name = "blocker-id") Long blockerId,
-                                                            @RequestParam(name = "blocked-id") Long blockedId) {
-        manageMemberUseCase.blockMember(new BlockMemberCommand(blockerId, blockedId));
+    @PostMapping("/block")
+    public ResponseEntity<BaseResponse<Object>> blockMember(@RequestParam(name = "blocked-id") Long blockedId) {
+        manageMemberUseCase.blockMember(new BlockMemberCommand(blockedId));
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 }

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -48,11 +48,10 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 
-    @PatchMapping("/profile/me/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> updateProfile(@PathVariable(name = "member-id") Long memberId,
-                                                              @RequestPart(value = "updateProfile") UpdateProfileReq req,
+    @PatchMapping("/profile/me")
+    public ResponseEntity<BaseResponse<Object>> updateProfile(@RequestPart(value = "updateProfile") UpdateProfileReq req,
                                                               @RequestPart(value = "profileImg", required = false) MultipartFile multipartFile) {
-        updateProfileFacade.updateProfile(memberId, req, multipartFile);
+        updateProfileFacade.updateProfile(req, multipartFile);
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -11,7 +11,6 @@ import com.justsayit.member.service.auth.usecase.AuthUseCase;
 import com.justsayit.member.service.management.command.BlockMemberCommand;
 import com.justsayit.member.service.management.usecase.ManageMemberUseCase;
 import com.justsayit.member.service.profile.UpdateProfileFacade;
-import com.justsayit.member.service.profile.command.GetProfileCmd;
 import com.justsayit.member.service.profile.dto.GetProfileRes;
 import com.justsayit.member.service.profile.usecase.ProfileUseCase;
 import lombok.RequiredArgsConstructor;
@@ -55,9 +54,9 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 
-    @GetMapping("/profile/me/{member-id}")
-    public ResponseEntity<BaseResponse<GetProfileRes>> getProfile(@PathVariable(name = "member-id") Long memberId) {
-        GetProfileRes getProfileRes = profileUseCase.getProfile(new GetProfileCmd(memberId));
+    @GetMapping("/profile/me")
+    public ResponseEntity<BaseResponse<GetProfileRes>> getProfile() {
+        GetProfileRes getProfileRes = profileUseCase.getProfile();
         return ResponseEntity.ok(BaseResponse.ofSuccess(getProfileRes));
     }
 

--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -42,9 +42,9 @@ public class MemberController {
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 
-    @PostMapping("/quit/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> quit(@PathVariable(name = "member-id") Long memberId) {
-        authUseCase.quit(memberId);
+    @PostMapping("/quit")
+    public ResponseEntity<BaseResponse<Object>> quit() {
+        authUseCase.quit();
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 

--- a/src/main/java/com/justsayit/member/service/auth/AuthService.java
+++ b/src/main/java/com/justsayit/member/service/auth/AuthService.java
@@ -2,6 +2,7 @@ package com.justsayit.member.service.auth;
 
 import com.justsayit.core.jwt.JwtTokenProvider;
 import com.justsayit.core.jwt.dto.JwtToken;
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.domain.PersonalInfo;
 import com.justsayit.member.domain.ProfileInfo;
@@ -60,7 +61,8 @@ public class AuthService implements AuthUseCase {
     }
 
     @Override
-    public void quit(Long memberId) {
+    public void quit() {
+        Long memberId = AuthServiceHelper.getMemberId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NoMemberException::new);
         member.deleteAccount();

--- a/src/main/java/com/justsayit/member/service/auth/usecase/AuthUseCase.java
+++ b/src/main/java/com/justsayit/member/service/auth/usecase/AuthUseCase.java
@@ -9,7 +9,7 @@ public interface AuthUseCase {
 
     LoginRes login(LoginCommand cmd);
 
-    void quit(Long memberId);
+    void quit();
 
     CheckIsJoinedRes checkIsJoined(CheckIsJoinedCmd checkIsJoinedCmd);
 }

--- a/src/main/java/com/justsayit/member/service/management/command/BlockMemberCommand.java
+++ b/src/main/java/com/justsayit/member/service/management/command/BlockMemberCommand.java
@@ -5,11 +5,9 @@ import lombok.Getter;
 @Getter
 public class BlockMemberCommand {
 
-    private Long blockerId;
     private Long blockedId;
 
-    public BlockMemberCommand(Long blockerId, Long blockedId) {
-        this.blockerId = blockerId;
+    public BlockMemberCommand(Long blockedId) {
         this.blockedId = blockedId;
     }
 }

--- a/src/main/java/com/justsayit/member/service/management/service/ManageMemberService.java
+++ b/src/main/java/com/justsayit/member/service/management/service/ManageMemberService.java
@@ -1,5 +1,6 @@
 package com.justsayit.member.service.management.service;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.BlockList;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
@@ -21,7 +22,8 @@ public class ManageMemberService implements ManageMemberUseCase {
 
     @Override
     public void blockMember(BlockMemberCommand cmd) {
-        Member blockerMember = MemberServiceHelper.findExistingMember(memberRepository, cmd.getBlockerId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member blockerMember = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Member blockedMember = MemberServiceHelper.findExistingMember(memberRepository, cmd.getBlockedId());
         BlockList blockList = new BlockList(blockerMember, blockedMember);
         blockListRepository.save(blockList);

--- a/src/main/java/com/justsayit/member/service/profile/ProfileService.java
+++ b/src/main/java/com/justsayit/member/service/profile/ProfileService.java
@@ -1,5 +1,6 @@
 package com.justsayit.member.service.profile;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.domain.ProfileInfo;
 import com.justsayit.member.repository.MemberRepository;
@@ -21,7 +22,8 @@ public class ProfileService implements ProfileUseCase {
 
     @Override
     public void updateProfile(UpdateProfileCmd cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         member.updateProfile(ProfileInfo.builder()
                 .nickname(cmd.getNickname())
                 .profileImg(cmd.getProfileImg())

--- a/src/main/java/com/justsayit/member/service/profile/ProfileService.java
+++ b/src/main/java/com/justsayit/member/service/profile/ProfileService.java
@@ -5,7 +5,6 @@ import com.justsayit.member.domain.Member;
 import com.justsayit.member.domain.ProfileInfo;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
-import com.justsayit.member.service.profile.command.GetProfileCmd;
 import com.justsayit.member.service.profile.command.UpdateProfileCmd;
 import com.justsayit.member.service.profile.dto.GetProfileRes;
 import com.justsayit.member.service.profile.usecase.ProfileUseCase;
@@ -31,8 +30,9 @@ public class ProfileService implements ProfileUseCase {
     }
 
     @Override
-    public GetProfileRes getProfile(GetProfileCmd cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+    public GetProfileRes getProfile() {
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         return GetProfileRes.builder()
                 .memberId(member.getId())
                 .loginType(member.getLoginType().toString())

--- a/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
+++ b/src/main/java/com/justsayit/member/service/profile/UpdateProfileFacade.java
@@ -20,13 +20,12 @@ public class UpdateProfileFacade {
     private final UploadImageUseCase uploadImageUseCase;
     private final ProfileUseCase profileUseCase;
 
-    public void updateProfile(Long memberId, UpdateProfileReq req, MultipartFile multipartFile) {
+    public void updateProfile(UpdateProfileReq req, MultipartFile multipartFile) {
         ProfileImgInfo profileImgInfo = createProfileImgInfo(req);
         if (Objects.nonNull(multipartFile)) {
             profileImgInfo = uploadImageUseCase.uploadProfileImg(multipartFile);
         }
         profileUseCase.updateProfile(UpdateProfileCmd.builder()
-                .memberId(memberId)
                 .nickname(req.getNickname())
                 .profileImg(profileImgInfo.getUrl())
                 .build());

--- a/src/main/java/com/justsayit/member/service/profile/command/UpdateProfileCmd.java
+++ b/src/main/java/com/justsayit/member/service/profile/command/UpdateProfileCmd.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 @Getter
 public class UpdateProfileCmd {
 
-    private Long memberId;
     private String nickname;
     private String profileImg;
 
     @Builder
-    public UpdateProfileCmd(Long memberId, String nickname, String profileImg) {
-        this.memberId = memberId;
+    public UpdateProfileCmd(String nickname, String profileImg) {
         this.nickname = nickname;
         this.profileImg = profileImg;
     }

--- a/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
+++ b/src/main/java/com/justsayit/member/service/profile/usecase/ProfileUseCase.java
@@ -1,6 +1,5 @@
 package com.justsayit.member.service.profile.usecase;
 
-import com.justsayit.member.service.profile.command.GetProfileCmd;
 import com.justsayit.member.service.profile.command.UpdateProfileCmd;
 import com.justsayit.member.service.profile.dto.GetProfileRes;
 
@@ -8,5 +7,5 @@ public interface ProfileUseCase {
 
     void updateProfile(UpdateProfileCmd cmd);
 
-    GetProfileRes getProfile(GetProfileCmd getProfileCmd);
+    GetProfileRes getProfile();
 }

--- a/src/main/java/com/justsayit/report/controller/ReportController.java
+++ b/src/main/java/com/justsayit/report/controller/ReportController.java
@@ -5,7 +5,10 @@ import com.justsayit.report.service.story.command.ReportStoryCommand;
 import com.justsayit.report.service.story.usecase.ReportStoryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/report")
 @RestController
@@ -15,12 +18,10 @@ public class ReportController {
     private final ReportStoryUseCase reportStoryUseCase;
 
 
-    @PostMapping("/stories/{story-id}/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> reportStory(@PathVariable(name = "member-id") Long memberId,
-                                                            @PathVariable(name = "story-id") Long storyId,
+    @PostMapping("/stories")
+    public ResponseEntity<BaseResponse<Object>> reportStory(@RequestParam(name = "story-id") Long storyId,
                                                             @RequestParam(name = "report-code") String reportCode) {
         reportStoryUseCase.reportStory(ReportStoryCommand.builder()
-                .memberId(memberId)
                 .storyId(storyId)
                 .reportCode(reportCode)
                 .build());

--- a/src/main/java/com/justsayit/report/service/story/ReportStoryService.java
+++ b/src/main/java/com/justsayit/report/service/story/ReportStoryService.java
@@ -1,5 +1,6 @@
 package com.justsayit.report.service.story;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
@@ -26,7 +27,8 @@ public class ReportStoryService implements ReportStoryUseCase {
 
     @Override
     public void reportStory(ReportStoryCommand cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Story story = storyRepository.findById(cmd.getStoryId())
                 .orElseThrow(NoStoryException::new);
         if (isMyStory(member, story)) {

--- a/src/main/java/com/justsayit/report/service/story/command/ReportStoryCommand.java
+++ b/src/main/java/com/justsayit/report/service/story/command/ReportStoryCommand.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 @Getter
 public class ReportStoryCommand {
 
-    private Long memberId;
     private Long storyId;
     private String reportCode;
 
     @Builder
-    public ReportStoryCommand(Long memberId, Long storyId, String reportCode) {
-        this.memberId = memberId;
+    public ReportStoryCommand(Long storyId, String reportCode) {
         this.storyId = storyId;
         this.reportCode = reportCode;
     }

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -36,13 +36,11 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 
-    @GetMapping("/me/latest/{member-id}")
-    public ResponseEntity<BaseResponse<GetStoryRes>> getMyStoriesOrderByLatest(@PathVariable(name = "member-id") Long memberId,
-                                                                               @RequestParam(name = "story-id", required = false) Long storyId,
+    @GetMapping("/me/latest")
+    public ResponseEntity<BaseResponse<GetStoryRes>> getMyStoriesOrderByLatest(@RequestParam(name = "story-id", required = false) Long storyId,
                                                                                @RequestParam(name = "emotion-code", required = false) String emotionCode,
                                                                                @RequestParam(name = "size") int size) {
         GetStoryRes res = getStoryUseCase.getMyStoriesOrderByLatest(
-                memberId,
                 StorySearchCondition.builder()
                         .storyId(storyId)
                         .emotion(emotionCode)

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -28,12 +28,11 @@ public class StoryController {
     private final EditStoryUseCase editStoryUseCase;
     private final EmpathizeUseCase empathizeUseCase;
 
-    @PostMapping("/new/{member-id}")
+    @PostMapping("/new")
     public ResponseEntity<BaseResponse<Object>> addStory(
-            @PathVariable(name = "member-id") Long memberId,
             @RequestPart(value = "storyInfo") AddStoryReq req,
             @RequestPart(value = "storyImg", required = false) List<MultipartFile> multipartFileList) {
-        addStoryFacade.addStory(memberId, req, multipartFileList);
+        addStoryFacade.addStory(req, multipartFileList);
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -91,10 +91,9 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 
-    @PatchMapping("/empathy/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> cancelEmmpathize(@PathVariable(name = "member-id") Long memberId,
-                                                                 @RequestParam(name = "story-id") Long storyId) {
-        empathizeUseCase.cancelEmpathize(new CancelEmpathizeCommand(memberId, storyId));
+    @PatchMapping("/empathy")
+    public ResponseEntity<BaseResponse<Object>> cancelEmmpathize(@RequestParam(name = "story-id") Long storyId) {
+        empathizeUseCase.cancelEmpathize(new CancelEmpathizeCommand(storyId));
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 }

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -62,12 +62,11 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 
-    @GetMapping("/all/latest/{member-id}")
-    public ResponseEntity<BaseResponse<GetStoryRes>> getAllStoriesOrderByLatest(@PathVariable(name = "member-id") Long memberId,
-                                                                                @RequestParam(name = "story-id", required = false) Long storyId,
+    @GetMapping("/all/latest")
+    public ResponseEntity<BaseResponse<GetStoryRes>> getAllStoriesOrderByLatest(@RequestParam(name = "story-id", required = false) Long storyId,
                                                                                 @RequestParam(name = "emotion-code", required = false) String emotionCode,
                                                                                 @RequestParam(name = "size") int size) {
-        GetStoryRes res = getStoryUseCase.getAllStoriesOrderByLatest(memberId,
+        GetStoryRes res = getStoryUseCase.getAllStoriesOrderByLatest(
                 StorySearchCondition.builder()
                         .storyId(storyId)
                         .emotion(emotionCode)

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -75,10 +75,9 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 
-    @PatchMapping("/remove/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> removeMyStory(@PathVariable(name = "member-id") Long memberId,
-                                                              @RequestParam(name = "story-id") Long storyId) {
-        editStoryUseCase.remove(new RemoveStoryCommand(memberId, storyId));
+    @PatchMapping("/remove")
+    public ResponseEntity<BaseResponse<Object>> removeMyStory(@RequestParam(name = "story-id") Long storyId) {
+        editStoryUseCase.remove(new RemoveStoryCommand(storyId));
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -49,13 +49,11 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 
-    @GetMapping("/me/oldest/{member-id}")
-    public ResponseEntity<BaseResponse<GetStoryRes>> getMyStoriesOrderByOldest(@PathVariable(name = "member-id") Long memberId,
-                                                                               @RequestParam(name = "story-id", required = false) Long storyId,
+    @GetMapping("/me/oldest")
+    public ResponseEntity<BaseResponse<GetStoryRes>> getMyStoriesOrderByOldest(@RequestParam(name = "story-id", required = false) Long storyId,
                                                                                @RequestParam(name = "emotion-code", required = false) String emotionCode,
                                                                                @RequestParam(name = "size") int size) {
         GetStoryRes res = getStoryUseCase.getMyStoriesOrderByOldest(
-                memberId,
                 StorySearchCondition.builder()
                         .storyId(storyId)
                         .emotion(emotionCode)

--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -81,12 +81,10 @@ public class StoryController {
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 
-    @PostMapping("/empathy/{member-id}")
-    public ResponseEntity<BaseResponse<Object>> empathize(@PathVariable(name = "member-id") Long memberId,
-                                                          @RequestParam(name = "story-id") Long storyId,
+    @PostMapping("/empathy")
+    public ResponseEntity<BaseResponse<Object>> empathize(@RequestParam(name = "story-id") Long storyId,
                                                           @RequestParam(name = "emotion-code") String emotionCode) {
         empathizeUseCase.empathize(EmpathizeCommand.builder()
-                .memberId(memberId)
                 .storyId(storyId)
                 .emotionCode(emotionCode)
                 .build());

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
@@ -1,5 +1,6 @@
 package com.justsayit.story.service.edit;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
@@ -24,7 +25,8 @@ public class EditStoryService implements EditStoryUseCase {
 
     @Override
     public void remove(RemoveStoryCommand cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Story story = storyRepository.findById(cmd.getStoryId())
                 .orElseThrow(NoStoryException::new);
         if (!story.getMemberId().equals(member.getId())) {

--- a/src/main/java/com/justsayit/story/service/edit/command/RemoveStoryCommand.java
+++ b/src/main/java/com/justsayit/story/service/edit/command/RemoveStoryCommand.java
@@ -5,11 +5,9 @@ import lombok.Getter;
 @Getter
 public class RemoveStoryCommand {
 
-    private Long memberId;
     private Long storyId;
 
-    public RemoveStoryCommand(Long memberId, Long storyId) {
-        this.memberId = memberId;
+    public RemoveStoryCommand(Long storyId) {
         this.storyId = storyId;
     }
 }

--- a/src/main/java/com/justsayit/story/service/empathize/EmpathizeService.java
+++ b/src/main/java/com/justsayit/story/service/empathize/EmpathizeService.java
@@ -50,13 +50,14 @@ public class EmpathizeService implements EmpathizeUseCase {
 
     @Override
     public void cancelEmpathize(CancelEmpathizeCommand cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Story story = storyRepository.findById(cmd.getStoryId())
                 .orElseThrow(NoStoryException::new);
         if (isMyStory(member, story)) {
             throw new EmpathizeMyStoryException();
         }
-        Empathy empathy = empathyRepository.searchValidEmpathy(cmd.getMemberId(), cmd.getStoryId());
+        Empathy empathy = empathyRepository.searchValidEmpathy(member.getId(), story.getId());
         if (isNull(empathy)) {
             throw new NoEmpathizeException();
         }

--- a/src/main/java/com/justsayit/story/service/empathize/EmpathizeService.java
+++ b/src/main/java/com/justsayit/story/service/empathize/EmpathizeService.java
@@ -1,5 +1,6 @@
 package com.justsayit.story.service.empathize;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
@@ -33,13 +34,14 @@ public class EmpathizeService implements EmpathizeUseCase {
 
     @Override
     public void empathize(EmpathizeCommand cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Story story = storyRepository.findById(cmd.getStoryId())
                 .orElseThrow(NoStoryException::new);
         if (isMyStory(member, story)) {
             throw new EmpathizeMyStoryException();
         }
-        Empathy empathy = empathyRepository.searchValidEmpathy(cmd.getMemberId(), cmd.getStoryId());
+        Empathy empathy = empathyRepository.searchValidEmpathy(member.getId(), story.getId());
         if (nonNull(empathy)) {
             throw new AlreadyEmpathizeException();
         }

--- a/src/main/java/com/justsayit/story/service/empathize/command/CancelEmpathizeCommand.java
+++ b/src/main/java/com/justsayit/story/service/empathize/command/CancelEmpathizeCommand.java
@@ -5,11 +5,9 @@ import lombok.Getter;
 @Getter
 public class CancelEmpathizeCommand {
 
-    private Long memberId;
     private Long storyId;
 
-    public CancelEmpathizeCommand(Long memberId, Long storyId) {
-        this.memberId = memberId;
+    public CancelEmpathizeCommand(Long storyId) {
         this.storyId = storyId;
     }
 }

--- a/src/main/java/com/justsayit/story/service/empathize/command/EmpathizeCommand.java
+++ b/src/main/java/com/justsayit/story/service/empathize/command/EmpathizeCommand.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 @Getter
 public class EmpathizeCommand {
 
-    private Long memberId;
     private Long storyId;
     private String emotionCode;
 
     @Builder
-    public EmpathizeCommand(Long memberId, Long storyId, String emotionCode) {
-        this.memberId = memberId;
+    public EmpathizeCommand(Long storyId, String emotionCode) {
         this.storyId = storyId;
         this.emotionCode = emotionCode;
     }

--- a/src/main/java/com/justsayit/story/service/read/GetStoryService.java
+++ b/src/main/java/com/justsayit/story/service/read/GetStoryService.java
@@ -1,5 +1,6 @@
 package com.justsayit.story.service.read;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
@@ -31,7 +32,8 @@ public class GetStoryService implements GetStoryUseCase {
     private final BlockListRepository blockListRepository;
 
     @Override
-    public GetStoryRes getMyStoriesOrderByLatest(Long memberId, StorySearchCondition cond) {
+    public GetStoryRes getMyStoriesOrderByLatest(StorySearchCondition cond) {
+        Long memberId = AuthServiceHelper.getMemberId();
         Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         List<Story> storyList = storyRepository.searchMyPostedStoriesOrderByLatest(memberId, cond);
 

--- a/src/main/java/com/justsayit/story/service/read/GetStoryService.java
+++ b/src/main/java/com/justsayit/story/service/read/GetStoryService.java
@@ -106,7 +106,8 @@ public class GetStoryService implements GetStoryUseCase {
     }
 
     @Override
-    public GetStoryRes getMyStoriesOrderByOldest(Long memberId, StorySearchCondition cond) {
+    public GetStoryRes getMyStoriesOrderByOldest(StorySearchCondition cond) {
+        Long memberId = AuthServiceHelper.getMemberId();
         Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         List<Story> storyList = storyRepository.searchMyPostedStoriesOrderByOldest(memberId, cond);
 

--- a/src/main/java/com/justsayit/story/service/read/GetStoryService.java
+++ b/src/main/java/com/justsayit/story/service/read/GetStoryService.java
@@ -180,7 +180,8 @@ public class GetStoryService implements GetStoryUseCase {
     }
 
     @Override
-    public GetStoryRes getAllStoriesOrderByLatest(Long memberId, StorySearchCondition cond) {
+    public GetStoryRes getAllStoriesOrderByLatest(StorySearchCondition cond) {
+        Long memberId = AuthServiceHelper.getMemberId();
         Member reader = MemberServiceHelper.findExistingMember(memberRepository, memberId);
 
         // 조회한 사람의 차단 사용자 목록

--- a/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
+++ b/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
@@ -7,7 +7,7 @@ public interface GetStoryUseCase {
 
     GetStoryRes getMyStoriesOrderByLatest(StorySearchCondition cond);
 
-    GetStoryRes getMyStoriesOrderByOldest(Long memberId, StorySearchCondition cond);
+    GetStoryRes getMyStoriesOrderByOldest(StorySearchCondition cond);
 
     GetStoryRes getAllStoriesOrderByLatest(Long memberId, StorySearchCondition cond);
 }

--- a/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
+++ b/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
@@ -5,7 +5,7 @@ import com.justsayit.story.service.read.dto.GetStoryRes;
 
 public interface GetStoryUseCase {
 
-    GetStoryRes getMyStoriesOrderByLatest(Long memberId, StorySearchCondition cond);
+    GetStoryRes getMyStoriesOrderByLatest(StorySearchCondition cond);
 
     GetStoryRes getMyStoriesOrderByOldest(Long memberId, StorySearchCondition cond);
 

--- a/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
+++ b/src/main/java/com/justsayit/story/service/read/usecase/GetStoryUseCase.java
@@ -9,5 +9,5 @@ public interface GetStoryUseCase {
 
     GetStoryRes getMyStoriesOrderByOldest(StorySearchCondition cond);
 
-    GetStoryRes getAllStoriesOrderByLatest(Long memberId, StorySearchCondition cond);
+    GetStoryRes getAllStoriesOrderByLatest(StorySearchCondition cond);
 }

--- a/src/main/java/com/justsayit/story/service/write/AddStoryFacade.java
+++ b/src/main/java/com/justsayit/story/service/write/AddStoryFacade.java
@@ -24,7 +24,7 @@ public class AddStoryFacade {
     private final UploadImageUseCase uploadImageUseCase;
     private final AddStoryUseCase addStoryUseCase;
 
-    public void addStory(Long memberId, AddStoryReq req, List<MultipartFile> multipartFileList) {
+    public void addStory(AddStoryReq req, List<MultipartFile> multipartFileList) {
         List<StoryPhoto> imgInfoList = new ArrayList<>();
         if (!CollectionUtils.isEmpty(multipartFileList)) {
             if (multipartFileList.size() > MAX_IMG_SIZE) {
@@ -33,7 +33,6 @@ public class AddStoryFacade {
             imgInfoList = uploadImageUseCase.uploadStoryImg(multipartFileList);
         }
         addStoryUseCase.addStory(AddStoryCommand.builder()
-                .memberId(memberId)
                 .emotion(req.getEmotion())
                 .content(req.getContent())
                 .storyPhotoList(imgInfoList)

--- a/src/main/java/com/justsayit/story/service/write/AddStoryService.java
+++ b/src/main/java/com/justsayit/story/service/write/AddStoryService.java
@@ -1,5 +1,6 @@
 package com.justsayit.story.service.write;
 
+import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.infra.s3.dto.StoryPhoto;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
@@ -27,7 +28,8 @@ public class AddStoryService implements AddStoryUseCase {
 
     @Override
     public void addStory(AddStoryCommand cmd) {
-        Member member = MemberServiceHelper.findExistingMember(memberRepository, cmd.getMemberId());
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
         Story story = Story.createStory(
                 member.getId(),
                 MainContent.of(cmd.getEmotion(), cmd.getContent()),

--- a/src/main/java/com/justsayit/story/service/write/command/AddStoryCommand.java
+++ b/src/main/java/com/justsayit/story/service/write/command/AddStoryCommand.java
@@ -12,7 +12,6 @@ import java.util.List;
 @AllArgsConstructor
 public class AddStoryCommand {
 
-    private Long memberId;
     private String emotion;
     private String content;
     private List<StoryPhoto> storyPhotoList;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #80 

### Key Point
- path-variable로 회원 id를 전달받으면서 동시에 토큰을 함께 서버로 보내고 있었음
- 토큰이 유효한 경우 시큐리티 컨텍스트에 사용자 정보를 저장하고 있음
- 따라서 path-variable 없이 컨텍스트에서 사용자 정보를 조회하도록 로직을 변경

### Other
- 없음