### PR TITLE
[Fix/#75] 스토리 조회 응답 결과에 공감한 감정 결과를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/story/domain/Emotion.java
+++ b/src/main/java/com/justsayit/story/domain/Emotion.java
@@ -16,18 +16,26 @@ public enum Emotion {
     ANGRY("EMOTION004"),
     ;
 
-
     private static final Map<String, Emotion> BY_CODE = new HashMap<>();
+    private static final Map<Emotion, String> BY_VALUE = new HashMap<>();
 
     static {
         for (Emotion e : values()) {
             BY_CODE.put(e.code, e);
+        }
+        for (Emotion e : values()) {
+            BY_VALUE.put(e, e.code);
         }
     }
 
     public static Emotion valueOfCode(String code) {
         return Optional.ofNullable(BY_CODE.get(code))
                 .orElseThrow(InvalidEmotionCodeException::new);
+    }
+
+    public static String codeOfValue(Emotion value) {
+        return Optional.ofNullable(BY_VALUE.get(value))
+                .orElse(null);
     }
 
     private final String code;

--- a/src/main/java/com/justsayit/story/service/read/GetStoryService.java
+++ b/src/main/java/com/justsayit/story/service/read/GetStoryService.java
@@ -6,6 +6,7 @@ import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
 import com.justsayit.member.service.management.repository.BlockListRepository;
 import com.justsayit.story.domain.Emotion;
+import com.justsayit.story.domain.Empathy;
 import com.justsayit.story.domain.Story;
 import com.justsayit.story.repository.EmpathyRepository;
 import com.justsayit.story.repository.StoryRepository;
@@ -52,6 +53,7 @@ public class GetStoryService implements GetStoryUseCase {
                                     EmpathyCountDto::getType,
                                     EmpathyCountDto::getCount
                             ));
+                    Empathy empathy = empathyRepository.searchValidEmpathy(memberId, story.getId());
                     return GetStoryRes.StoryInfo.builder()
                             // id 정보
                             .storyId(story.getId())
@@ -95,6 +97,11 @@ public class GetStoryService implements GetStoryUseCase {
                                     .happinessCount(empathyCountMap.getOrDefault(Emotion.HAPPINESS, 0L))
                                     .build()
                                     .calcTotalCount())
+
+                            // 조회한 사람의 공감 결과
+                            .resultOfEmpathize(GetStoryRes.StoryInfo.ResultOfEmpathize.builder()
+                                    .emotionCode(Emotion.codeOfValue(getType(empathy)))
+                                    .build())
 
                             .createdAt(story.getCreatedAt())
                             .updatedAt(story.getUpdatedAt())
@@ -126,6 +133,7 @@ public class GetStoryService implements GetStoryUseCase {
                                     EmpathyCountDto::getType,
                                     EmpathyCountDto::getCount
                             ));
+                    Empathy empathy = empathyRepository.searchValidEmpathy(memberId, story.getId());
                     return GetStoryRes.StoryInfo.builder()
                             // id 정보
                             .storyId(story.getId())
@@ -169,6 +177,11 @@ public class GetStoryService implements GetStoryUseCase {
                                     .happinessCount(empathyCountMap.getOrDefault(Emotion.HAPPINESS, 0L))
                                     .build()
                                     .calcTotalCount())
+
+                            // 조회한 사람의 공감 결과
+                            .resultOfEmpathize(GetStoryRes.StoryInfo.ResultOfEmpathize.builder()
+                                    .emotionCode(Emotion.codeOfValue(getType(empathy)))
+                                    .build())
 
                             .createdAt(story.getCreatedAt())
                             .updatedAt(story.getUpdatedAt())
@@ -206,6 +219,7 @@ public class GetStoryService implements GetStoryUseCase {
                                     EmpathyCountDto::getType,
                                     EmpathyCountDto::getCount
                             ));
+                    Empathy empathy = empathyRepository.searchValidEmpathy(memberId, story.getId());
                     return GetStoryRes.StoryInfo.builder()
                             // id 정보
                             .storyId(story.getId())
@@ -250,11 +264,20 @@ public class GetStoryService implements GetStoryUseCase {
                                     .build()
                                     .calcTotalCount())
 
+                            // 조회한 사람의 공감 결과
+                            .resultOfEmpathize(GetStoryRes.StoryInfo.ResultOfEmpathize.builder()
+                                    .emotionCode(Emotion.codeOfValue(getType(empathy)))
+                                    .build())
+
                             .createdAt(story.getCreatedAt())
                             .updatedAt(story.getUpdatedAt())
                             .build();
                 })
                 .collect(Collectors.toList());
         return new GetStoryRes(hasNext, res);
+    }
+
+    private Emotion getType(Empathy empathy) {
+        return empathy != null ? empathy.getType() : null;
     }
 }

--- a/src/main/java/com/justsayit/story/service/read/dto/GetStoryRes.java
+++ b/src/main/java/com/justsayit/story/service/read/dto/GetStoryRes.java
@@ -30,11 +30,12 @@ public class GetStoryRes {
         private StoryMainContent storyMainContent;
         private StoryMetaInfo storyMetaInfo;
         private EmotionOfEmpathy emotionOfEmpathy;
+        private ResultOfEmpathize resultOfEmpathize;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
         @Builder
-        public StoryInfo(Long storyId, String storyUUID, Long writerId, boolean mine, ProfileInfo profileInfo, StoryMainContent storyMainContent, StoryMetaInfo storyMetaInfo, EmotionOfEmpathy emotionOfEmpathy, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        public StoryInfo(Long storyId, String storyUUID, Long writerId, boolean mine, ProfileInfo profileInfo, StoryMainContent storyMainContent, StoryMetaInfo storyMetaInfo, EmotionOfEmpathy emotionOfEmpathy, ResultOfEmpathize resultOfEmpathize, LocalDateTime createdAt, LocalDateTime updatedAt) {
             this.storyId = storyId;
             this.storyUUID = storyUUID;
             this.writerId = writerId;
@@ -43,6 +44,7 @@ public class GetStoryRes {
             this.storyMainContent = storyMainContent;
             this.storyMetaInfo = storyMetaInfo;
             this.emotionOfEmpathy = emotionOfEmpathy;
+            this.resultOfEmpathize = resultOfEmpathize;
             this.createdAt = createdAt;
             this.updatedAt = updatedAt;
         }
@@ -152,6 +154,16 @@ public class GetStoryRes {
                     totalCount += surprisedCount;
                 }
                 return this;
+            }
+        }
+
+        @Getter
+        public static class ResultOfEmpathize {
+            private String emotionCode;
+
+            @Builder
+            public ResultOfEmpathize(String emotionCode) {
+                this.emotionCode = emotionCode;
             }
         }
     }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #75 

### Key Point
- 감정 값을 코드로 바꾸는 메서드를 정의
- 특정 스토리에 대해 공감한 결과가 없다면 null 반환(내 스토리 or 공감하지 않은 다른 사용자의 스토리)

### Other
- 없음