### PR TITLE
[Feat/#89] 오늘의 감정 조회하기 API를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/mood/controller/MoodController.java
+++ b/src/main/java/com/justsayit/mood/controller/MoodController.java
@@ -2,14 +2,13 @@ package com.justsayit.mood.controller;
 
 import com.justsayit.core.template.response.BaseResponse;
 import com.justsayit.mood.controller.request.SaveMoodReq;
-import com.justsayit.mood.service.command.SaveMoodCommand;
-import com.justsayit.mood.service.usecase.SaveMoodUseCase;
+import com.justsayit.mood.service.get.dto.GetTodayMoodRes;
+import com.justsayit.mood.service.get.usecase.GetMoodUseCase;
+import com.justsayit.mood.service.save.command.SaveMoodCommand;
+import com.justsayit.mood.service.save.usecase.SaveMoodUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/mood")
 @RestController
@@ -17,10 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class MoodController {
 
     private final SaveMoodUseCase saveMoodUseCase;
+    private final GetMoodUseCase getMoodUseCase;
 
     @PostMapping("/new")
     public ResponseEntity<BaseResponse<Object>> saveMood(@RequestBody SaveMoodReq req) {
         saveMoodUseCase.saveMood(new SaveMoodCommand(req.getMoodCode()));
         return ResponseEntity.ok(BaseResponse.ofSuccess());
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<BaseResponse<GetTodayMoodRes>> getTodayMoodRecord() {
+        GetTodayMoodRes res = getMoodUseCase.getTodayMoodRecord();
+        return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 }

--- a/src/main/java/com/justsayit/mood/domain/MoodCode.java
+++ b/src/main/java/com/justsayit/mood/domain/MoodCode.java
@@ -17,16 +17,22 @@ public enum MoodCode {
     ;
 
     private static final Map<String, MoodCode> BY_CODE = new HashMap<>();
+    private static final Map<MoodCode, String> BY_VALUE = new HashMap<>();
 
     static {
         for (MoodCode moodCode : values()) {
             BY_CODE.put(moodCode.getCode(), moodCode);
+            BY_VALUE.put(moodCode, moodCode.getCode());
         }
     }
 
     public static MoodCode valueOfCode(String code) {
         return Optional.ofNullable(BY_CODE.get(code))
                 .orElseThrow(InvalidMoodCodeException::new);
+    }
+
+    public static String codeOfValue(MoodCode moodCode) {
+        return BY_VALUE.get(moodCode);
     }
 
     private final String code;

--- a/src/main/java/com/justsayit/mood/repository/MoodRepository.java
+++ b/src/main/java/com/justsayit/mood/repository/MoodRepository.java
@@ -3,5 +3,5 @@ package com.justsayit.mood.repository;
 import com.justsayit.mood.domain.Mood;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MoodRepository extends JpaRepository<Mood, Long> {
+public interface MoodRepository extends JpaRepository<Mood, Long>, MoodRepositoryCustom {
 }

--- a/src/main/java/com/justsayit/mood/repository/MoodRepositoryCustom.java
+++ b/src/main/java/com/justsayit/mood/repository/MoodRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.justsayit.mood.repository;
+
+import com.justsayit.mood.domain.Mood;
+
+import java.util.List;
+
+public interface MoodRepositoryCustom {
+
+    List<Mood> searchTodayMoodOrderByOldest(Long memberId);
+}

--- a/src/main/java/com/justsayit/mood/repository/MoodRepositoryCustomImpl.java
+++ b/src/main/java/com/justsayit/mood/repository/MoodRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.justsayit.mood.repository;
+
+import com.justsayit.mood.domain.Mood;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.justsayit.mood.domain.QMood.mood;
+
+public class MoodRepositoryCustomImpl implements MoodRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MoodRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<Mood> searchTodayMoodOrderByOldest(Long memberId) {
+        LocalDateTime today = LocalDateTime.now();
+        return queryFactory.selectFrom(mood)
+                .where(
+                        mood.createdAt.between(
+                                today.toLocalDate().atStartOfDay(),
+                                today.toLocalDate().atTime(LocalTime.MAX)
+                        )
+                )
+                .orderBy(mood.createdAt.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/justsayit/mood/service/get/GetMoodService.java
+++ b/src/main/java/com/justsayit/mood/service/get/GetMoodService.java
@@ -1,0 +1,44 @@
+package com.justsayit.mood.service.get;
+
+import com.justsayit.core.security.auth.AuthServiceHelper;
+import com.justsayit.member.domain.Member;
+import com.justsayit.member.repository.MemberRepository;
+import com.justsayit.member.service.MemberServiceHelper;
+import com.justsayit.mood.domain.Mood;
+import com.justsayit.mood.domain.MoodCode;
+import com.justsayit.mood.repository.MoodRepository;
+import com.justsayit.mood.service.get.dto.GetTodayMoodRes;
+import com.justsayit.mood.service.get.usecase.GetMoodUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetMoodService implements GetMoodUseCase {
+
+    private final MemberRepository memberRepository;
+    private final MoodRepository moodRepository;
+
+    @Override
+    public GetTodayMoodRes getTodayMoodRecord() {
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
+        List<Mood> moodList = moodRepository.searchTodayMoodOrderByOldest(memberId);
+        List<GetTodayMoodRes.MyMood> myMoodList = moodList.stream()
+                .map(mood -> GetTodayMoodRes.MyMood.builder()
+                        .moodId(mood.getId())
+                        .moodCode(MoodCode.codeOfValue(mood.getType()))
+                        .createdAt(mood.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+        return GetTodayMoodRes.builder()
+                .memberName(member.getProfileInfo().getNickname())
+                .myMoodRecord(myMoodList)
+                .build();
+    }
+}

--- a/src/main/java/com/justsayit/mood/service/get/dto/GetTodayMoodRes.java
+++ b/src/main/java/com/justsayit/mood/service/get/dto/GetTodayMoodRes.java
@@ -1,0 +1,35 @@
+package com.justsayit.mood.service.get.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class GetTodayMoodRes {
+
+    private String memberName;
+    private List<MyMood> myMoodRecord;
+
+    @Getter
+    public static class MyMood {
+
+        private Long moodId;
+        private String moodCode;
+        private LocalDateTime createdAt;
+
+        @Builder
+        public MyMood(Long moodId, String moodCode, LocalDateTime createdAt) {
+            this.moodId = moodId;
+            this.moodCode = moodCode;
+            this.createdAt = createdAt;
+        }
+    }
+
+    @Builder
+    public GetTodayMoodRes(String memberName, List<MyMood> myMoodRecord) {
+        this.memberName = memberName;
+        this.myMoodRecord = myMoodRecord;
+    }
+}

--- a/src/main/java/com/justsayit/mood/service/get/usecase/GetMoodUseCase.java
+++ b/src/main/java/com/justsayit/mood/service/get/usecase/GetMoodUseCase.java
@@ -1,0 +1,8 @@
+package com.justsayit.mood.service.get.usecase;
+
+import com.justsayit.mood.service.get.dto.GetTodayMoodRes;
+
+public interface GetMoodUseCase {
+
+    GetTodayMoodRes getTodayMoodRecord();
+}

--- a/src/main/java/com/justsayit/mood/service/save/SaveMoodService.java
+++ b/src/main/java/com/justsayit/mood/service/save/SaveMoodService.java
@@ -1,4 +1,4 @@
-package com.justsayit.mood.service;
+package com.justsayit.mood.service.save;
 
 import com.justsayit.core.security.auth.AuthServiceHelper;
 import com.justsayit.member.domain.Member;
@@ -6,8 +6,8 @@ import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
 import com.justsayit.mood.domain.Mood;
 import com.justsayit.mood.repository.MoodRepository;
-import com.justsayit.mood.service.command.SaveMoodCommand;
-import com.justsayit.mood.service.usecase.SaveMoodUseCase;
+import com.justsayit.mood.service.save.command.SaveMoodCommand;
+import com.justsayit.mood.service.save.usecase.SaveMoodUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/justsayit/mood/service/save/command/SaveMoodCommand.java
+++ b/src/main/java/com/justsayit/mood/service/save/command/SaveMoodCommand.java
@@ -1,4 +1,4 @@
-package com.justsayit.mood.service.command;
+package com.justsayit.mood.service.save.command;
 
 import lombok.Getter;
 

--- a/src/main/java/com/justsayit/mood/service/save/usecase/SaveMoodUseCase.java
+++ b/src/main/java/com/justsayit/mood/service/save/usecase/SaveMoodUseCase.java
@@ -1,0 +1,8 @@
+package com.justsayit.mood.service.save.usecase;
+
+import com.justsayit.mood.service.save.command.SaveMoodCommand;
+
+public interface SaveMoodUseCase {
+
+    void saveMood(SaveMoodCommand cmd);
+}

--- a/src/main/java/com/justsayit/mood/service/usecase/SaveMoodUseCase.java
+++ b/src/main/java/com/justsayit/mood/service/usecase/SaveMoodUseCase.java
@@ -1,8 +1,0 @@
-package com.justsayit.mood.service.usecase;
-
-import com.justsayit.mood.service.command.SaveMoodCommand;
-
-public interface SaveMoodUseCase {
-
-    void saveMood(SaveMoodCommand cmd);
-}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #89 

### Key Point
- 현재 서버의 시간대를 기준으로 하루의 시작과 끝 사이에 기록된 감정 기록을 조회
- between 문법을 사용하여 쿼리 작성
  - today.toLocalDate().atStartOfDay()
  - today.toLocalDate().atTime(LocalTime.MAX)
  
### Other
- 없음  