### PR TITLE
[Feat/#43] 스토리 수정하기 API를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/story/controller/StoryController.java
+++ b/src/main/java/com/justsayit/story/controller/StoryController.java
@@ -2,6 +2,8 @@ package com.justsayit.story.controller;
 
 import com.justsayit.core.template.response.BaseResponse;
 import com.justsayit.story.controller.request.AddStoryReq;
+import com.justsayit.story.controller.request.EditStoryReq;
+import com.justsayit.story.service.edit.EditStoryFacade;
 import com.justsayit.story.service.edit.command.RemoveStoryCommand;
 import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
 import com.justsayit.story.service.empathize.command.CancelEmpathizeCommand;
@@ -24,6 +26,7 @@ import java.util.List;
 public class StoryController {
 
     private final AddStoryFacade addStoryFacade;
+    private final EditStoryFacade editStoryFacade;
     private final GetStoryUseCase getStoryUseCase;
     private final EditStoryUseCase editStoryUseCase;
     private final EmpathizeUseCase empathizeUseCase;
@@ -92,8 +95,15 @@ public class StoryController {
     }
 
     @PatchMapping("/empathy")
-    public ResponseEntity<BaseResponse<Object>> cancelEmmpathize(@RequestParam(name = "story-id") Long storyId) {
+    public ResponseEntity<BaseResponse<Object>> cancelEmpathize(@RequestParam(name = "story-id") Long storyId) {
         empathizeUseCase.cancelEmpathize(new CancelEmpathizeCommand(storyId));
+        return ResponseEntity.ok(BaseResponse.ofSuccess());
+    }
+
+    @PatchMapping("/edit")
+    public ResponseEntity<BaseResponse<Object>> edit(@RequestPart(value = "storyInfo") EditStoryReq req,
+                                                          @RequestPart(value = "newImg", required = false) List<MultipartFile> multipartFileList) {
+        editStoryFacade.edit(req, multipartFileList);
         return ResponseEntity.ok(BaseResponse.ofSuccess());
     }
 }

--- a/src/main/java/com/justsayit/story/controller/request/EditStoryReq.java
+++ b/src/main/java/com/justsayit/story/controller/request/EditStoryReq.java
@@ -1,0 +1,20 @@
+package com.justsayit.story.controller.request;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EditStoryReq {
+
+    private Long storyId;
+    private String emotion;
+    private String content;
+    private boolean opened;
+    private boolean anonymous;
+    private List<String> emotionOfEmpathy;
+    private List<Long> removedPhoto;
+}

--- a/src/main/java/com/justsayit/story/domain/Story.java
+++ b/src/main/java/com/justsayit/story/domain/Story.java
@@ -75,12 +75,12 @@ public class Story extends BaseJpaEntity {
         this.mainContent = mainContent;
     }
 
-    public void changePhotoList(List<Photo> photoList) {
-        this.photoList = photoList;
-    }
-
     public void changeMetaInfo(MetaInfo metaInfo) {
         this.metaInfo = metaInfo;
+    }
+
+    public void changeEmotionOfEmpathy(EmotionOfEmpathy emotionOfEmpathy) {
+        this.emotionOfEmpathy = emotionOfEmpathy;
     }
 
     public void remove() {

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryFacade.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryFacade.java
@@ -1,0 +1,46 @@
+package com.justsayit.story.service.edit;
+
+import com.justsayit.infra.s3.dto.StoryPhoto;
+import com.justsayit.infra.s3.usecase.UploadImageUseCase;
+import com.justsayit.story.controller.request.EditStoryReq;
+import com.justsayit.story.exception.InvalidNumberOfImgException;
+import com.justsayit.story.service.edit.command.EditStoryCommand;
+import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EditStoryFacade {
+
+    private final int MAX_IMG_SIZE = 4;
+    private final UploadImageUseCase uploadImageUseCase;
+    private final EditStoryUseCase editStoryUseCase;
+
+    public void edit(EditStoryReq req, List<MultipartFile> multipartFileList) {
+        List<StoryPhoto> imgInfoList = new ArrayList<>();
+        if (!CollectionUtils.isEmpty(multipartFileList)) {
+            if (multipartFileList.size() > MAX_IMG_SIZE) {
+                throw new InvalidNumberOfImgException();
+            }
+            imgInfoList = uploadImageUseCase.uploadStoryImg(multipartFileList);
+        }
+        editStoryUseCase.edit(EditStoryCommand.builder()
+                .storyId(req.getStoryId())
+                .content(req.getContent())
+                .emotion(req.getEmotion())
+                .opened(req.isOpened())
+                .anonymous(req.isAnonymous())
+                .emotionOfEmpathy(req.getEmotionOfEmpathy())
+                .newPhoto(imgInfoList)
+                .removedPhoto(req.getRemovedPhoto())
+                .build());
+    }
+}

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
@@ -1,19 +1,24 @@
 package com.justsayit.story.service.edit;
 
 import com.justsayit.core.security.auth.AuthServiceHelper;
+import com.justsayit.infra.s3.dto.StoryPhoto;
 import com.justsayit.member.domain.Member;
 import com.justsayit.member.repository.MemberRepository;
 import com.justsayit.member.service.MemberServiceHelper;
-import com.justsayit.story.domain.Story;
+import com.justsayit.story.domain.*;
 import com.justsayit.story.exception.NoStoryException;
 import com.justsayit.story.exception.NotMyStoryException;
+import com.justsayit.story.repository.PhotoRepository;
 import com.justsayit.story.repository.StoryRepository;
+import com.justsayit.story.service.edit.command.EditStoryCommand;
 import com.justsayit.story.service.edit.command.RemoveStoryCommand;
 import com.justsayit.story.service.edit.usecase.EditStoryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,7 @@ public class EditStoryService implements EditStoryUseCase {
 
     private final MemberRepository memberRepository;
     private final StoryRepository storyRepository;
+    private final PhotoRepository photoRepository;
 
     @Override
     public void remove(RemoveStoryCommand cmd) {
@@ -33,5 +39,38 @@ public class EditStoryService implements EditStoryUseCase {
             throw new NotMyStoryException();
         }
         story.remove();
+    }
+
+    @Override
+    public void edit(EditStoryCommand cmd) {
+        Long memberId = AuthServiceHelper.getMemberId();
+        Member member = MemberServiceHelper.findExistingMember(memberRepository, memberId);
+        Story story = storyRepository.findById(cmd.getStoryId())
+                .orElseThrow(NoStoryException::new);
+        if (!story.getMemberId().equals(member.getId())) {
+            throw new NotMyStoryException();
+        }
+
+        /* 제거된 사진 */
+
+        photoRepository.deleteAllById(cmd.getRemovedPhoto());
+
+        /* 스토리 내용 수정 */
+        story.changeMainContent(MainContent.of(cmd.getEmotion(), cmd.getContent()));
+        story.changeMetaInfo(MetaInfo.ofModified(cmd.isOpened(), cmd.isAnonymous()));
+        story.changeEmotionOfEmpathy(EmotionOfEmpathy.of(cmd.getEmotionOfEmpathy()));
+
+        /* 새롭게 추가된 사진 저장 */
+        List<StoryPhoto> imgInfoList = cmd.getNewPhoto();
+        if (!imgInfoList.isEmpty()) {
+            savePhoto(story, imgInfoList);
+        }
+    }
+
+    private void savePhoto(Story story, List<StoryPhoto> imgInfoList) {
+        List<Photo> photoList = imgInfoList.stream()
+                .map(storyPhoto -> Photo.createPhoto(story, storyPhoto.getUrl()))
+                .collect(Collectors.toList());
+        photoRepository.saveAll(photoList);
     }
 }

--- a/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
+++ b/src/main/java/com/justsayit/story/service/edit/EditStoryService.java
@@ -52,7 +52,6 @@ public class EditStoryService implements EditStoryUseCase {
         }
 
         /* 제거된 사진 */
-
         photoRepository.deleteAllById(cmd.getRemovedPhoto());
 
         /* 스토리 내용 수정 */

--- a/src/main/java/com/justsayit/story/service/edit/command/EditStoryCommand.java
+++ b/src/main/java/com/justsayit/story/service/edit/command/EditStoryCommand.java
@@ -1,0 +1,23 @@
+package com.justsayit.story.service.edit.command;
+
+import com.justsayit.infra.s3.dto.StoryPhoto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EditStoryCommand {
+
+    private Long storyId;
+    private String emotion;
+    private String content;
+    private List<Long> removedPhoto;
+    private List<StoryPhoto> newPhoto;
+    private boolean opened;
+    private boolean anonymous;
+    private List<String> emotionOfEmpathy;
+}

--- a/src/main/java/com/justsayit/story/service/edit/usecase/EditStoryUseCase.java
+++ b/src/main/java/com/justsayit/story/service/edit/usecase/EditStoryUseCase.java
@@ -1,8 +1,11 @@
 package com.justsayit.story.service.edit.usecase;
 
+import com.justsayit.story.service.edit.command.EditStoryCommand;
 import com.justsayit.story.service.edit.command.RemoveStoryCommand;
 
 public interface EditStoryUseCase {
 
     void remove(RemoveStoryCommand cmd);
+
+    void edit(EditStoryCommand cmd);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #43 

### Key Point
- 기존 사진 중 삭제된 사진의 id값을 받아 DB에서 DELETE
- 새롭게 추가된 사진은 멀티파트로 전달받아 새롭게 업로드 후 저장
- 스토리 수정 시 modified 칼럼은 true로 변경됨
- 사진 업로드 서비스와 스토리 수정 서비스를 퍼사드 계층에서 호출

### Other
- Photo 서비스를 Story 도메인과 분리시키기