### PR TITLE
[Feat/#111] 애플 소셜 로그인을 구현한다

### DIFF
--- a/src/main/java/com/justsayit/member/controller/MemberController.java
+++ b/src/main/java/com/justsayit/member/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.justsayit.member.controller;
 
 import com.justsayit.core.template.response.BaseResponse;
-import com.justsayit.member.controller.request.BlockMemberReq;
-import com.justsayit.member.controller.request.JoinReq;
-import com.justsayit.member.controller.request.NaverLoginReq;
-import com.justsayit.member.controller.request.UpdateProfileReq;
+import com.justsayit.member.controller.request.*;
+import com.justsayit.member.service.auth.apple.AppleLoginCommand;
 import com.justsayit.member.service.auth.dto.OAuthLoginRes;
 import com.justsayit.member.service.auth.naver.NaverLoginCommand;
 import com.justsayit.member.service.auth.usecase.OAuthUseCase;
@@ -34,6 +32,12 @@ public class MemberController {
     @PostMapping("/oauth/naver")
     public ResponseEntity<BaseResponse<OAuthLoginRes>> naverLogin(@RequestBody NaverLoginReq req) {
         OAuthLoginRes res = oAuthUseCase.naverLogin(new NaverLoginCommand(req.getToken()));
+        return ResponseEntity.ok(BaseResponse.ofSuccess(res));
+    }
+
+    @PostMapping("/oauth/apple")
+    public ResponseEntity<BaseResponse<OAuthLoginRes>> appleLogin(@RequestBody AppleLoginReq req) {
+        OAuthLoginRes res = oAuthUseCase.appleLogin(new AppleLoginCommand(req.getToken()));
         return ResponseEntity.ok(BaseResponse.ofSuccess(res));
     }
 

--- a/src/main/java/com/justsayit/member/controller/request/AppleLoginReq.java
+++ b/src/main/java/com/justsayit/member/controller/request/AppleLoginReq.java
@@ -1,0 +1,12 @@
+package com.justsayit.member.controller.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleLoginReq {
+
+    private String token;
+}

--- a/src/main/java/com/justsayit/member/exception/FailToGetApplePublicKey.java
+++ b/src/main/java/com/justsayit/member/exception/FailToGetApplePublicKey.java
@@ -1,0 +1,19 @@
+package com.justsayit.member.exception;
+
+public class FailToGetApplePublicKey extends RuntimeException {
+
+    public FailToGetApplePublicKey() {
+    }
+
+    public FailToGetApplePublicKey(String message) {
+        super(message);
+    }
+
+    public FailToGetApplePublicKey(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FailToGetApplePublicKey(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/member/exception/FailToVerifyAppleIdentityToken.java
+++ b/src/main/java/com/justsayit/member/exception/FailToVerifyAppleIdentityToken.java
@@ -1,0 +1,19 @@
+package com.justsayit.member.exception;
+
+public class FailToVerifyAppleIdentityToken extends RuntimeException {
+
+    public FailToVerifyAppleIdentityToken() {
+    }
+
+    public FailToVerifyAppleIdentityToken(String message) {
+        super(message);
+    }
+
+    public FailToVerifyAppleIdentityToken(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FailToVerifyAppleIdentityToken(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/member/exception/InvalidAppleIdentityToken.java
+++ b/src/main/java/com/justsayit/member/exception/InvalidAppleIdentityToken.java
@@ -1,0 +1,19 @@
+package com.justsayit.member.exception;
+
+public class InvalidAppleIdentityToken extends RuntimeException {
+
+    public InvalidAppleIdentityToken() {
+    }
+
+    public InvalidAppleIdentityToken(String message) {
+        super(message);
+    }
+
+    public InvalidAppleIdentityToken(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidAppleIdentityToken(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/OAuthService.java
+++ b/src/main/java/com/justsayit/member/service/auth/OAuthService.java
@@ -36,4 +36,17 @@ public class OAuthService implements OAuthUseCase {
         JwtToken jwtToken = jwtTokenProvider.createToken(member.getId());
         return OAuthLoginRes.isJoined(email, jwtToken.getAccessToken());
     }
+
+    @Override
+    public OAuthLoginRes appleLogin(OAuthLoginCommand cmd) {
+        OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(cmd);
+        String email = oAuthInfoResponse.getEmail();
+        Provider provider = oAuthInfoResponse.getProvider();
+        Member member = memberRepository.findByEmailAndProvider(email, provider);
+        if (isNull(member)) {
+            return OAuthLoginRes.isNotJoined(email);
+        }
+        JwtToken jwtToken = jwtTokenProvider.createToken(member.getId());
+        return OAuthLoginRes.isJoined(email, jwtToken.getAccessToken());
+    }
 }

--- a/src/main/java/com/justsayit/member/service/auth/apple/AppleApiClient.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/AppleApiClient.java
@@ -1,0 +1,42 @@
+package com.justsayit.member.service.auth.apple;
+
+import com.justsayit.member.service.auth.dto.OAuthInfoResponse;
+import com.justsayit.member.service.auth.dto.OAuthProvider;
+import com.justsayit.member.service.auth.usecase.OAuthApiClient;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class AppleApiClient implements OAuthApiClient {
+
+    @Value("${oauth.apple.url.api}")
+    private String GET_PUBLIC_KEY_URL;
+    private final String SUB = "sub";
+    private final String EMAIL = "email";
+    private final AppleJwtUtils appleJwtUtils;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String identityToken) {
+        ApplePublicKeyResponse response = getApplePublicKey();
+        Claims claims = appleJwtUtils.verifyIdentityTokenAndGetPayload(identityToken, response);
+        String sub = String.valueOf(claims.get(SUB));
+        String email = String.valueOf(claims.get(EMAIL));
+        return new AppleInfoResponse(sub, email);
+    }
+
+    public ApplePublicKeyResponse getApplePublicKey() {
+        ResponseEntity<ApplePublicKeyResponse> response = restTemplate.getForEntity(GET_PUBLIC_KEY_URL, ApplePublicKeyResponse.class);
+        return response.getBody();
+    }
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.APPLE;
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/apple/AppleInfoResponse.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/AppleInfoResponse.java
@@ -1,0 +1,25 @@
+package com.justsayit.member.service.auth.apple;
+
+import com.justsayit.member.domain.Provider;
+import com.justsayit.member.service.auth.dto.OAuthInfoResponse;
+
+public class AppleInfoResponse implements OAuthInfoResponse {
+
+    private String sub;
+    private String email;
+
+    public AppleInfoResponse(String sub, String email) {
+        this.sub = sub;
+        this.email = email;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.APPLE;
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/apple/AppleJwtUtils.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/AppleJwtUtils.java
@@ -1,0 +1,82 @@
+package com.justsayit.member.service.auth.apple;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.justsayit.member.exception.FailToGetApplePublicKey;
+import com.justsayit.member.exception.FailToVerifyAppleIdentityToken;
+import com.justsayit.member.exception.InvalidAppleIdentityToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public final class AppleJwtUtils {
+
+    @Value("${oauth.apple.client-id}")
+    private String CLIENT_ID;
+    @Value("${oauth.apple.issuer}")
+    private String ISSUER;
+    private final String KID = "kid";
+    private final String ALG = "alg";
+    private final String CHARSET_NAME = "UTF-8";
+    private final String DELIMITER_POINT = ".";
+
+    public Claims verifyIdentityTokenAndGetPayload(String identityToken, ApplePublicKeyResponse response) {
+        try {
+            /* JWT header */
+            Map<String, String> header = new ObjectMapper().readValue(base64Decode(getHeaderOfIdentityToken(identityToken)), Map.class);
+            ApplePublicKeyResponse.Key key = findPublicKey(r다esponse, header);
+
+            /* RSA 복호화를 위한 공개키 생성 */
+            byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());
+            byte[] eBytes = Base64.getUrlDecoder().decode(key.getE());
+            BigInteger n = new BigInteger(1, nBytes);
+            BigInteger e = new BigInteger(1, eBytes);
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+            KeyFactory keyFactory = KeyFactory.getInstance(key.getKty());
+            PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+            /* JWT payload */
+            Claims body = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+
+            /* 토큰 검증 */
+            if (!(body.getIssuer().equals(ISSUER) && body.getAudience().equals(CLIENT_ID))) {
+                throw new InvalidAppleIdentityToken();
+            }
+
+            /* payload 반환 */
+            return Jwts.parserBuilder().setSigningKey(publicKey).build().parseClaimsJws(identityToken).getBody();
+        } catch (Exception e) {
+            throw new FailToVerifyAppleIdentityToken();
+        }
+    }
+
+    private ApplePublicKeyResponse.Key findPublicKey(ApplePublicKeyResponse response, Map<String, String> header) {
+        return response.getKeys().stream()
+                .filter(key -> key.getKid().equals(header.get(KID)) && key.getAlg().equals(header.get(ALG)))
+                .findFirst()
+                .orElseThrow(FailToGetApplePublicKey::new);
+    }
+
+    private String base64Decode(String identityToken) throws UnsupportedEncodingException {
+        return new String(Base64.getDecoder().decode(identityToken), CHARSET_NAME);
+    }
+
+    private String getHeaderOfIdentityToken(String identityToken) {
+        return identityToken.substring(0, identityToken.indexOf(DELIMITER_POINT));
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/apple/AppleJwtUtils.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/AppleJwtUtils.java
@@ -35,7 +35,7 @@ public final class AppleJwtUtils {
         try {
             /* JWT header */
             Map<String, String> header = new ObjectMapper().readValue(base64Decode(getHeaderOfIdentityToken(identityToken)), Map.class);
-            ApplePublicKeyResponse.Key key = findPublicKey(r다esponse, header);
+            ApplePublicKeyResponse.Key key = findPublicKey(response, header);
 
             /* RSA 복호화를 위한 공개키 생성 */
             byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());

--- a/src/main/java/com/justsayit/member/service/auth/apple/AppleLoginCommand.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/AppleLoginCommand.java
@@ -1,0 +1,26 @@
+package com.justsayit.member.service.auth.apple;
+
+import com.justsayit.member.service.auth.command.OAuthLoginCommand;
+import com.justsayit.member.service.auth.dto.OAuthProvider;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleLoginCommand implements OAuthLoginCommand {
+
+    private String token;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.APPLE;
+    }
+
+    @Override
+    public String token() {
+        return token;
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/apple/ApplePublicKeyResponse.java
+++ b/src/main/java/com/justsayit/member/service/auth/apple/ApplePublicKeyResponse.java
@@ -1,0 +1,21 @@
+package com.justsayit.member.service.auth.apple;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ApplePublicKeyResponse {
+
+    private List<Key> keys;
+
+    @Getter
+    public static class Key {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;
+        private String e;
+    }
+}

--- a/src/main/java/com/justsayit/member/service/auth/naver/NaverApiClient.java
+++ b/src/main/java/com/justsayit/member/service/auth/naver/NaverApiClient.java
@@ -25,9 +25,9 @@ public class NaverApiClient implements OAuthApiClient {
     private final RestTemplate restTemplate;
 
     @Override
-    public OAuthInfoResponse requestOauthInfo(String token) {
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
         HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setBearerAuth(token);
+        httpHeaders.setBearerAuth(accessToken);
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
         /* 헤더 토큰을 전달하기 위해 get 대신 post 메서드 사용 */

--- a/src/main/java/com/justsayit/member/service/auth/usecase/OAuthUseCase.java
+++ b/src/main/java/com/justsayit/member/service/auth/usecase/OAuthUseCase.java
@@ -5,5 +5,7 @@ import com.justsayit.member.service.auth.dto.OAuthLoginRes;
 
 public interface OAuthUseCase {
 
-    OAuthLoginRes naverLogin(OAuthLoginCommand req);
+    OAuthLoginRes naverLogin(OAuthLoginCommand cmd);
+
+    OAuthLoginRes appleLogin(OAuthLoginCommand cmd);
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,11 @@ jwt:
     expiration-time: 60000  # 1분 -> 30분으로 변경
 
 oauth:
+  apple:
+    issuer: apple-issuer
+    client-id: app-client-id
+    url:
+      api: https://appleid.apple.com/auth/keys
   naver:
     url:
       api: https://openapi.naver.com/v1/nid/me


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #111 

### Key Point
- 애플 공개키 조회
- identity token의 헤더를 디코딩하여 일치하는 공개키 재료를 찾아 공개키를 생성
- identity token을 공개키로 RSA 복호화를 하여 payload 조회
- 사용자 메일, 고유 id값을 조회

### Other
- 없음