### PR TITLE
[Feat/#117] 애플 로그인 관련 예외 핸들러를 추가한다

### DIFF
--- a/src/main/java/com/justsayit/core/exception/advice/MemberExceptionHandler.java
+++ b/src/main/java/com/justsayit/core/exception/advice/MemberExceptionHandler.java
@@ -2,9 +2,7 @@ package com.justsayit.core.exception.advice;
 
 import com.justsayit.core.template.response.BaseResponse;
 import com.justsayit.core.template.response.ResponseCode;
-import com.justsayit.member.exception.AlreadyExistsMemberException;
-import com.justsayit.member.exception.InvalidNicknameLengthException;
-import com.justsayit.member.exception.NoMemberException;
+import com.justsayit.member.exception.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,5 +26,23 @@ public class MemberExceptionHandler {
     public ResponseEntity<BaseResponse<Object>> noMemberException(InvalidNicknameLengthException e) {
         return ResponseEntity.badRequest()
                 .body(BaseResponse.ofFail(ResponseCode.INVALID_NICKNAME_LENGTH));
+    }
+
+    @ExceptionHandler(InvalidAppleIdentityToken.class)
+    public ResponseEntity<BaseResponse<Object>> invalidAppleIdentityToken(InvalidAppleIdentityToken e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.INVALID_APPLE_IDENTITY_TOKEN));
+    }
+
+    @ExceptionHandler(FailToVerifyAppleIdentityToken.class)
+    public ResponseEntity<BaseResponse<Object>> failToVerifyAppleIdentityToken(FailToVerifyAppleIdentityToken e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.FAIL_TO_VERIFY_APPLE_IDENTITY_TOKEN));
+    }
+
+    @ExceptionHandler(FailToGetApplePublicKey.class)
+    public ResponseEntity<BaseResponse<Object>> failToGetApplePublicKey(FailToGetApplePublicKey e) {
+        return ResponseEntity.badRequest()
+                .body(BaseResponse.ofFail(ResponseCode.FAIL_TO_GET_APPLE_PUBLIC_KEY));
     }
 }

--- a/src/main/java/com/justsayit/core/template/response/ResponseCode.java
+++ b/src/main/java/com/justsayit/core/template/response/ResponseCode.java
@@ -17,6 +17,9 @@ public enum ResponseCode {
     NO_MEMBER("3000", "회원이 존재하지 않습니다."),
     ALREADY_EXISTS_MEMBER("3001", "이미 가입한 회원입니다."),
     INVALID_NICKNAME_LENGTH("3002", "닉네임은 2글자 이상, 12글자 이하여야 합니다."),
+    INVALID_APPLE_IDENTITY_TOKEN("3003", "유효하지 않은 identity token입니다."),
+    FAIL_TO_VERIFY_APPLE_IDENTITY_TOKEN("3004", "identity token 검증에 실패했습니다."),
+    FAIL_TO_GET_APPLE_PUBLIC_KEY("3005", "공개키 재료값을 찾는데 실패했습니다."),
 
     // 4000 - S3
     FILE_SIZE_OVERFLOW("4000", "개별 사진 사이즈는 최대 10MB, 총합 사이즈는 최대 100MB를 초과할 수 없습니다."),
@@ -39,8 +42,7 @@ public enum ResponseCode {
 
     // 7000 - MOOD
     INVALID_MOOD_CODE("7000", "잘못된 감정코드입니다."),
-    RECENT_SAVED_MOOD_EXISTS("7001", "최근에 저장한 감정이 있습니다."),
-    ;
+    RECENT_SAVED_MOOD_EXISTS("7001", "최근에 저장한 감정이 있습니다."),;
 
     private String code;
     private String message;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #117 

### Key Point
- 예외 핸들러 추가
- 예외 메시지 enum 추가

### Other
- 없음