### PR TITLE
[Fix/#102] 익명 글 조회 시 사용자 정보가 노출되지 안도록 수정한다

### DIFF
--- a/src/main/java/com/justsayit/story/service/read/GetStoryService.java
+++ b/src/main/java/com/justsayit/story/service/read/GetStoryService.java
@@ -62,10 +62,7 @@ public class GetStoryService implements GetStoryUseCase {
                             .mine(memberId.equals(story.getMemberId()))
 
                             // 작성자 프로필 정보
-                            .profileInfo(GetStoryRes.StoryInfo.ProfileInfo.builder()
-                                    .nickname(member.getProfileInfo().getNickname())
-                                    .profileImg(member.getProfileInfo().getProfileImg())
-                                    .build())
+                            .profileInfo(GetStoryRes.StoryInfo.ProfileInfo.of(member.getProfileInfo().getProfileImg(), member.getProfileInfo().getNickname()))
 
                             // 스토리 메타정보
                             .storyMetaInfo(GetStoryRes.StoryInfo.StoryMetaInfo.builder()
@@ -142,10 +139,7 @@ public class GetStoryService implements GetStoryUseCase {
                             .mine(memberId.equals(story.getMemberId()))
 
                             // 작성자 프로필 정보
-                            .profileInfo(GetStoryRes.StoryInfo.ProfileInfo.builder()
-                                    .nickname(member.getProfileInfo().getNickname())
-                                    .profileImg(member.getProfileInfo().getProfileImg())
-                                    .build())
+                            .profileInfo(GetStoryRes.StoryInfo.ProfileInfo.of(member.getProfileInfo().getProfileImg(), member.getProfileInfo().getNickname()))
 
                             // 스토리 메타정보
                             .storyMetaInfo(GetStoryRes.StoryInfo.StoryMetaInfo.builder()
@@ -228,10 +222,10 @@ public class GetStoryService implements GetStoryUseCase {
                             .mine(reader.getId().equals(writer.getId()))
 
                             // 작성자 프로필 정보
-                            .profileInfo(GetStoryRes.StoryInfo.ProfileInfo.builder()
-                                    .nickname(writer.getProfileInfo().getNickname())
-                                    .profileImg(writer.getProfileInfo().getProfileImg())
-                                    .build())
+                            .profileInfo(
+                                    story.getMetaInfo().isAnonymous() ?
+                                            GetStoryRes.StoryInfo.ProfileInfo.ofDefault() :
+                                            GetStoryRes.StoryInfo.ProfileInfo.of(writer.getProfileInfo().getProfileImg(), writer.getProfileInfo().getNickname()))
 
                             // 스토리 메타정보
                             .storyMetaInfo(GetStoryRes.StoryInfo.StoryMetaInfo.builder()

--- a/src/main/java/com/justsayit/story/service/read/dto/GetStoryRes.java
+++ b/src/main/java/com/justsayit/story/service/read/dto/GetStoryRes.java
@@ -53,13 +53,22 @@ public class GetStoryRes {
         @Getter
         public static class ProfileInfo {
 
+            private static final String DEFAULT_IMG = "https://jsi-bucket.s3.ap-northeast-2.amazonaws.com/default_profile.png";
+            private static final String DEFAULT_NICKNAME = "익명";
             private String profileImg;
             private String nickname;
 
-            @Builder
-            public ProfileInfo(String profileImg, String nickname) {
+            private ProfileInfo(String profileImg, String nickname) {
                 this.profileImg = profileImg;
                 this.nickname = nickname;
+            }
+
+            public static ProfileInfo ofDefault() {
+                return new ProfileInfo(DEFAULT_IMG, DEFAULT_NICKNAME);
+            }
+
+            public static ProfileInfo of(String profileImg, String nickname) {
+                return new ProfileInfo(profileImg, nickname);
             }
         }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #102 

### Key Point
- 익명 글 조회 시 익명으로 처리

### Other
- 없음