### PR TITLE
[Fix/#122] 회원가입 여부 조회 쿼리의 조건절을 수정한다

### DIFF
--- a/src/main/java/com/justsayit/member/repository/MemberRepository.java
+++ b/src/main/java/com/justsayit/member/repository/MemberRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("select m from Member m where m.email = :email and m.provider = :provider")
+    @Query("select m from Member m where m.email = :email and m.provider = :provider and m.status = 'INACTIVE'")
     Member findByEmailAndProvider(@Param("email") String email, @Param("provider") Provider provider);
 }

--- a/src/main/java/com/justsayit/member/repository/MemberRepository.java
+++ b/src/main/java/com/justsayit/member/repository/MemberRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("select m from Member m where m.email = :email and m.provider = :provider and m.status = 'INACTIVE'")
+    @Query("select m from Member m where m.email = :email and m.provider = :provider and m.status = 'ACTIVE'")
     Member findByEmailAndProvider(@Param("email") String email, @Param("provider") Provider provider);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
- #122 

### Key Point
- 회원가입 여부를 조회할 때 탈퇴한 회원인지 확인하도록 쿼리 조건절을 수정

### Other
- 없음 